### PR TITLE
BinarySize for size of encoded objects

### DIFF
--- a/wire.go
+++ b/wire.go
@@ -16,6 +16,12 @@ const (
 	ReadSliceChunkSize = 1024
 )
 
+// Return size of o after encoding
+func BinarySize(o interface{}, err *error) int {
+	rv, rt := reflect.ValueOf(o), reflect.TypeOf(o)
+	return reflectBinarySize(rv, rt, Options{}, err)
+}
+
 func ReadBinary(o interface{}, r io.Reader, lmt int, n *int, err *error) (res interface{}) {
 	rv, rt := reflect.ValueOf(o), reflect.TypeOf(o)
 	if rv.Kind() == reflect.Ptr {


### PR DESCRIPTION
Motivated by needing to length prefix messages over the network. But maybe nice to have regardless.
