### PR TITLE
Make time parsing more flexible

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -88,7 +88,7 @@ var (
 )
 
 const (
-	iso8601 = "2006-01-02T15:04:05.000Z" // forced microseconds
+	RFC3339Millis = "2006-01-02T15:04:05.000Z" // forced microseconds
 )
 
 // NOTE: do not access typeInfos directly, but call GetTypeInfo()
@@ -950,7 +950,7 @@ func writeReflectJSON(rv reflect.Value, rt reflect.Type, opts Options, w io.Writ
 		if rt == timeType {
 			// Special case: time.Time
 			t := rv.Interface().(time.Time).UTC()
-			str := t.Format(iso8601)
+			str := t.Format(RFC3339Millis)
 			jsonBytes, err_ := json.Marshal(str)
 			if err_ != nil {
 				*err = err_

--- a/reflect.go
+++ b/reflect.go
@@ -750,8 +750,8 @@ func readReflectJSON(rv reflect.Value, rt reflect.Type, opts Options, o interfac
 				*err = errors.New(Fmt("Expected string but got type %v", reflect.TypeOf(o)))
 				return
 			}
-			//log.Info("Read time", "t", str)
-			t, err_ := time.Parse(iso8601, str)
+			// try three ways, seconds, milliseconds, or microseconds...
+			t, err_ := time.Parse(time.RFC3339Nano, str)
 			if err_ != nil {
 				*err = err_
 				return

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,49 @@
+package wire
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Input struct {
+	Date time.Time `json:"date"`
+}
+
+func TestJSONTimeParse(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected time.Time
+		encoded  string
+	}{
+		{
+			"2017-03-31T16:45:15Z",
+			time.Date(2017, 3, 31, 16, 45, 15, 0, time.UTC),
+			"2017-03-31T16:45:15.000Z",
+		},
+		{
+			"2017-03-31T16:45:15.972Z",
+			time.Date(2017, 3, 31, 16, 45, 15, 972000000, time.UTC),
+			"2017-03-31T16:45:15.972Z",
+		},
+		{
+			"2017-03-31T16:45:15.972167Z",
+			time.Date(2017, 3, 31, 16, 45, 15, 972167000, time.UTC),
+			"2017-03-31T16:45:15.972Z",
+		},
+	}
+
+	for _, tc := range cases {
+		var err error
+		var parsed Input
+		data := []byte(fmt.Sprintf(`{"date":"%s"}`, tc.input))
+		ReadJSONPtr(&parsed, data, &err)
+		if assert.Nil(t, err, "%s: %+v", tc.input, err) {
+			assert.Equal(t, tc.expected, parsed.Date)
+			out := JSONBytes(parsed)
+			assert.Equal(t, fmt.Sprintf(`{"date":"%s"}`, tc.encoded), string(out))
+		}
+	}
+}


### PR DESCRIPTION
Handle variable number of decimal places for the second when parsing json strings into time.Time.

Resolves https://github.com/tendermint/tendermint/issues/440