### PR TITLE
Stop overflows in ReadBinaryBytes

### DIFF
--- a/util.go
+++ b/util.go
@@ -22,7 +22,7 @@ func BinaryBytes(o interface{}) []byte {
 // ptr: a pointer to the object to be filled
 func ReadBinaryBytes(d []byte, ptr interface{}) error {
 	r, n, err := bytes.NewBuffer(d), new(int), new(error)
-	ReadBinaryPtr(ptr, r, 0, n, err)
+	ReadBinaryPtr(ptr, r, len(d), n, err)
 	return *err
 }
 


### PR DESCRIPTION
This addresses #14 and #12 simply by adding a hard limit to the parsed size when we know it in advance.

Maybe this is too hard a limit, but I am sure we can figure out a safe number based on the size of the input.  So far the tendermint tests all run through with these values.