### PR TITLE
doc.go, examples_test.go: improve DevExp with doc and examples

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,69 @@
+/*
+go-wire is our custom codec package for serializing and deserializing
+data and structures as binary and JSON blobs.
+
+In order to get started with go-wire we need to:
+
+1) Choose the receiving structure for deserializing.
+It MUST be an interface{} and during registration it MUST be
+wrapped as a struct for example
+
+    struct { Receiver }{}
+
+2) Decide the IDs for the respective types that we'll be dealing with.
+We shall call these the concrete types.
+
+3) Register the receiving structure as well as each of the concrete types.
+Typically do this in the init function so that it gets run before other functions are invoked
+    
+
+  func init() {
+    wire.RegisterInterface(
+	struct { Receiver }{},
+	wire.ConcreteType{&bcMessage{}, 0x01},
+	wire.ConcreteType{&bcResponse{}, 0x02},
+	wire.ConcreteType{&bcStatus{}, 0x03},
+    )
+  }
+
+  type bcMessage struct {
+    Content string
+    Height int
+  }
+
+  type bcResponse struct {
+    Status int
+    Message string 
+  }
+
+  type bcResponse struct {
+    Status int
+    Message string 
+  }
+
+
+Encoding to binary is performed by invoking wire.WriteBinary. You'll need to provide
+the data to be encoded/serialized as well as where to store it and storage for
+the number of bytes written as well as any error encountered
+
+  var n int
+  var err error
+  buf := new(bytes.Buffer)
+  bm := &bcMessage{Message: "Tendermint", Height: 100}
+  wire.WriteBinary(bm, buf, &n, &err)
+
+Decoding from binary is performed by invoking wire.ReadBinary. The data being decoded
+has to be retrieved from the decoding receiver that we previously defined i.e. Receiver
+for example
+
+  recv := wire.ReadBinary(struct{ Receiver }{}, buf, 0, &n, &err).(struct{ Receiver }).Receiver
+  decoded := recv.(*bcMessage)
+  fmt.Printf("Decoded: %#v\n", decoded)
+
+Note that in the decoding example we used
+
+  struct { Receiver }{} --> .(struct{ Receiver }).Receiver
+
+to receive the value. That correlates with the type that we registered in wire.RegisterInterface
+*/
+package wire

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Tendermint. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wire_test
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+
+	"github.com/tendermint/go-wire"
+)
+
+func Example_RegisterInterface() {
+	type Receiver interface{}
+	type bcMessage struct {
+		Message string
+		Height  int
+	}
+
+	type bcResponse struct {
+		Status  int
+		Message string
+	}
+
+	type bcStatus struct {
+		Peers int
+	}
+
+	var _ = wire.RegisterInterface(
+		struct{ Receiver }{},
+		wire.ConcreteType{&bcMessage{}, 0x01},
+		wire.ConcreteType{&bcResponse{}, 0x02},
+		wire.ConcreteType{&bcStatus{}, 0x03},
+	)
+}
+
+func Example_EndToEnd_ReadWriteBinary() {
+	type Receiver interface{}
+	type bcMessage struct {
+		Message string
+		Height  int
+	}
+
+	type bcResponse struct {
+		Status  int
+		Message string
+	}
+
+	type bcStatus struct {
+		Peers int
+	}
+
+	var _ = wire.RegisterInterface(
+		struct{ Receiver }{},
+		wire.ConcreteType{&bcMessage{}, 0x01},
+		wire.ConcreteType{&bcResponse{}, 0x02},
+		wire.ConcreteType{&bcStatus{}, 0x03},
+	)
+
+	var n int
+	var err error
+	buf := new(bytes.Buffer)
+	bm := &bcMessage{Message: "Tendermint", Height: 100}
+	wire.WriteBinary(bm, buf, &n, &err)
+	if err != nil {
+		log.Fatalf("writeBinary: %v", err)
+	}
+	fmt.Printf("Encoded: %x\n", buf.Bytes())
+
+	recv := wire.ReadBinary(struct{ Receiver }{}, buf, 0, &n, &err).(struct{ Receiver }).Receiver
+	if err != nil {
+		log.Fatalf("readBinary: %v", err)
+	}
+	decoded := recv.(*bcMessage)
+	fmt.Printf("Decoded: %#v\n", decoded)
+
+	// Output:
+	// Encoded: 01010a54656e6465726d696e740164
+	// Decoded: &wire_test.bcMessage{Message:"Tendermint", Height:100}
+}

--- a/wire.go
+++ b/wire.go
@@ -67,6 +67,9 @@ func ReadBinaryPtrLengthPrefixed(o interface{}, r io.Reader, lmt int, n *int, er
 	return res
 }
 
+// WriteBinary is the binary encoder. Its arguments are the subject to be
+// encoded, the writer that'll receive the encoded bytes, as well as a
+// receiver to store the bytes written and any error encountered.
 func WriteBinary(o interface{}, w io.Writer, n *int, err *error) {
 	rv := reflect.ValueOf(o)
 	rt := reflect.TypeOf(o)


### PR DESCRIPTION
Updates #32 

* Added an overview doc.go file
* Added end to end examples that are runnable and copy+pastable
for RegisterInterface, WriteBinary, ReadBinary