### PR TITLE
failing test for backwards compatibility with omitempty

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -803,3 +803,44 @@ func TestUnwrap(t *testing.T) {
 	}
 
 }
+
+// -----------------------------------------------
+
+type MyStruct1 struct {
+	A string `json:"a"`
+}
+
+type MyStruct2 struct {
+	A string `json:"a"`
+	B string `json:"b,omitempty"`
+}
+
+func TestReadOmitEmptyJSON(t *testing.T) {
+	s := &MyStruct1{"hi"}
+	s2 := new(MyStruct2)
+
+	b := JSONBytes(s)
+	err := ReadJSONBytes(b, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.A != s2.A {
+		t.Fatalf("Expected values to match, got %s, expected %s", s2.A, s.A)
+	}
+}
+
+func TestReadOmitEmptyBinary(t *testing.T) {
+	s := &MyStruct1{"hi"}
+	s2 := new(MyStruct2)
+
+	b := BinaryBytes(s)
+	err := ReadBinaryBytes(b, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.A != s2.A {
+		t.Fatalf("Expected values to match, got %s, expected %s", s2.A, s.A)
+	}
+}


### PR DESCRIPTION
Failing test illustrating unexpected behaviour with `omitempty` and binary encoding