### PR TITLE
byteslice: ensure no MaxInt overflow before invoking make for slice

### DIFF
--- a/byteslice.go
+++ b/byteslice.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"io"
+	"math"
 
 	cmn "github.com/tendermint/tmlibs/common"
 )
@@ -18,6 +19,10 @@ func ReadByteSlice(r io.Reader, lmt int, n *int, err *error) []byte {
 	}
 	if length < 0 {
 		*err = ErrBinaryReadInvalidLength
+		return nil
+	}
+	if length > math.MaxInt32 {
+		*err = ErrBinaryReadOverflow
 		return nil
 	}
 	if lmt != 0 && lmt < cmn.MaxInt(length, *n+length) {

--- a/byteslice_test.go
+++ b/byteslice_test.go
@@ -3,6 +3,8 @@ package wire
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadByteSliceEquality(t *testing.T) {
@@ -124,4 +126,15 @@ func TestGetByteSlice(t *testing.T) {
 	if !bytes.Equal(got, testBytes) {
 		t.Error("Expected to read %v, got %v", testBytes, got)
 	}
+}
+
+// Issues:
+// + https://github.com/tendermint/go-wire/issues/25
+// + https://github.com/tendermint/go-wire/issues/37
+func TestFuzzBinaryLengthOverflowsCaught(t *testing.T) {
+	n, err := int(0), error(nil)
+	var x []byte
+	bs := ReadBinary(x, bytes.NewReader([]byte{8, 127, 255, 255, 255, 255, 255, 255, 255}), 0, &n, &err)
+	require.Equal(t, err, ErrBinaryReadOverflow, "expected to detect a length overflow")
+	require.Nil(t, bs, "expecting no bytes read out")
 }


### PR DESCRIPTION
Fixes https://github.com/tendermint/go-wire/issues/25
Fixes https://github.com/tendermint/go-wire/issues/37
Fixes https://github.com/tendermint/tendermint/issues/722

Before attempting to allocate a buffer to hold
decoded lengths, check that it doesn't exceed
math.MaxInt32 ie (2^31) - 1.
In the case of overflows, report ErrBinaryReadOverflow
and don't attempt to read anything.

This issue was found firstly by @mveytsman in #25
and then independently confirmed by go-fuzz in tendermint.