### PR TITLE
*Binary: ensure exported embedded types for registration

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -114,8 +114,14 @@ type ConcreteType struct {
 	Byte byte
 }
 
-// Must use this to register an interface to properly decode the
-// underlying concrete type.
+// This function should be used to register the receiving interface that will
+// be used to decoded an underlying concrete type. If embedding the interface
+// in a struct, the interface MUST be the only field and it MUST be an exported field.
+// For example:
+//	RegisterInterface(struct{ Animal }{}, ConcreteType{&foo, 0x01)
+// OR
+//	type exportedField struct { Animal animal }
+//	RegisterInterface(exportedField{}, ConcreteType{&foo, 0x01)
 func RegisterInterface(o interface{}, ctypes ...ConcreteType) *TypeInfo {
 	it := GetTypeFromStructDeclaration(o)
 	if it.Kind() != reflect.Interface {


### PR DESCRIPTION
Updates #34

Document and add tests to ensure/lockin that exported embedded
types must be used, lest decoding/ReadBinary fails.