### PR TITLE
fix default encoding of time and bytes

### DIFF
--- a/byteslice.go
+++ b/byteslice.go
@@ -32,9 +32,14 @@ func ReadByteSlice(r io.Reader, lmt int, n *int, err *error) []byte {
 		return nil
 	}
 
+	if length == 0 {
+		return nil // zero value for []byte
+	}
+
 	buf := make([]byte, length)
 	ReadFull(buf, r, n, err)
 	return buf
+
 }
 
 func PutByteSlice(buf []byte, bz []byte) (n int, err error) {

--- a/reflect.go
+++ b/reflect.go
@@ -115,7 +115,7 @@ type ConcreteType struct {
 }
 
 // This function should be used to register the receiving interface that will
-// be used to decoded an underlying concrete type. The interface MUST be embedded
+// be used to decode an underlying concrete type. The interface MUST be embedded
 // in a struct, and the interface MUST be the only field and it MUST be exported.
 // For example:
 //      RegisterInterface(struct{ Animal }{}, ConcreteType{&foo, 0x01})

--- a/time.go
+++ b/time.go
@@ -12,14 +12,28 @@ Writes nanoseconds since epoch but with millisecond precision.
 This is to ease compatibility with Javascript etc.
 */
 
+// WriteTime writes the number of nanoseconds since
+// January 1, 1970 UTC to the Writer as an Int64.
+// If the given time is less than January 1, 1970 UTC, a -1 is written.
 func WriteTime(t time.Time, w io.Writer, n *int, err *error) {
 	nanosecs := t.UnixNano()
 	millisecs := nanosecs / 1000000
-	WriteInt64(millisecs*1000000, w, n, err)
+	if nanosecs < 0 {
+		WriteInt64(-1, w, n, err)
+	} else {
+		WriteInt64(millisecs*1000000, w, n, err)
+	}
 }
 
+// ReadTime reads an Int64 from the Reader, interprets it as
+// the number of nanoseconds since January 1, 1970 UTC, and
+// returns the corresponding time. If the Int64 read is -1, it returns
+// the zero value for time.Time.
 func ReadTime(r io.Reader, n *int, err *error) time.Time {
 	t := ReadInt64(r, n, err)
+	if t == -1 {
+		return time.Time{}
+	}
 	if t%1000000 != 0 {
 		cmn.PanicSanity("Time cannot have sub-millisecond precision")
 	}


### PR DESCRIPTION
Prior to this, empty byte arrays were decoded as `[]byte{}` rather than `[]byte(nil)`, and empty time.Time structs were decoded as some date in 1754, since time.UnixNano is undefined for values that cant be represented by int64, including the default time (https://golang.org/pkg/time/#Time.UnixNano)