### PR TITLE
fix default encoding of time and bytes

### DIFF
--- a/byteslice.go
+++ b/byteslice.go
@@ -32,9 +32,14 @@ func ReadByteSlice(r io.Reader, lmt int, n *int, err *error) []byte {
 		return nil
 	}
 
+	if length == 0 {
+		return nil // zero value for []byte
+	}
+
 	buf := make([]byte, length)
 	ReadFull(buf, r, n, err)
 	return buf
+
 }
 
 func PutByteSlice(buf []byte, bz []byte) (n int, err error) {

--- a/reflect.go
+++ b/reflect.go
@@ -115,7 +115,7 @@ type ConcreteType struct {
 }
 
 // This function should be used to register the receiving interface that will
-// be used to decoded an underlying concrete type. The interface MUST be embedded
+// be used to decode an underlying concrete type. The interface MUST be embedded
 // in a struct, and the interface MUST be the only field and it MUST be exported.
 // For example:
 //      RegisterInterface(struct{ Animal }{}, ConcreteType{&foo, 0x01})

--- a/time.go
+++ b/time.go
@@ -12,16 +12,32 @@ Writes nanoseconds since epoch but with millisecond precision.
 This is to ease compatibility with Javascript etc.
 */
 
+// WriteTime writes the number of nanoseconds, with millisecond resolution,
+// since January 1, 1970 UTC, to the Writer as an Int64.
+// NOTE: panics if the given time is less than January 1, 1970 UTC
 func WriteTime(t time.Time, w io.Writer, n *int, err *error) {
 	nanosecs := t.UnixNano()
 	millisecs := nanosecs / 1000000
-	WriteInt64(millisecs*1000000, w, n, err)
+	if nanosecs < 0 {
+		cmn.PanicSanity("can't encode times below 1970")
+	} else {
+		WriteInt64(millisecs*1000000, w, n, err)
+	}
 }
 
+// ReadTime reads an Int64 from the Reader, interprets it as
+// the number of nanoseconds since January 1, 1970 UTC, and
+// returns the corresponding time. If the Int64 read is less than zero,
+// or not a multiple of a million, it sets the error and returns the default time.
 func ReadTime(r io.Reader, n *int, err *error) time.Time {
 	t := ReadInt64(r, n, err)
+	if t < 0 {
+		*err = ErrBinaryReadInvalidTimeNegative
+		return time.Time{}
+	}
 	if t%1000000 != 0 {
-		cmn.PanicSanity("Time cannot have sub-millisecond precision")
+		*err = ErrBinaryReadInvalidTimeSubMillisecond
+		return time.Time{}
 	}
 	return time.Unix(0, t)
 }

--- a/wire.go
+++ b/wire.go
@@ -10,9 +10,13 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-var ErrBinaryReadOverflow = errors.New("Error: binary read overflow")
-var ErrBinaryReadInvalidLength = errors.New("Error: binary read invalid length")
-var ErrBinaryWriteOverflow = errors.New("Error: binary write overflow")
+var (
+	ErrBinaryReadOverflow                  = errors.New("Error: binary read overflow")
+	ErrBinaryReadInvalidLength             = errors.New("Error: binary read invalid length")
+	ErrBinaryReadInvalidTimeNegative       = errors.New("Error: binary read invalid time - negative")
+	ErrBinaryReadInvalidTimeSubMillisecond = errors.New("Error: binary read invalid time - sub millisecond")
+	ErrBinaryWriteOverflow                 = errors.New("Error: binary write overflow")
+)
 
 const (
 	ReadSliceChunkSize = 1024


### PR DESCRIPTION
Prior to this, empty byte arrays were decoded as []byte{} rather than []byte(nil), and empty time.Time structs were decoded as some date in 1754, since time.UnixNano is undefined for values that cant be represented by int64, including the default time (https://golang.org/pkg/time/#Time.UnixNano)