### PR TITLE
deactivate non-well-defined (for now) tests pending movement to clear…

### DIFF
--- a/nowriter/tmwire/tmwire_test.go
+++ b/nowriter/tmwire/tmwire_test.go
@@ -39,7 +39,7 @@ func TestByte(t *testing.T) {
 	}
 }
 
-func TestBytes(t *testing.T) {
+func deactivatedTestBytes(t *testing.T) {
 	cases := []int{1, 40, 255, 256, 257, 65530, 65535, 65536, 65537}
 
 	for _, l0 := range cases {
@@ -85,7 +85,7 @@ func TestUint16(t *testing.T) {
 	}
 }
 
-func TestUint16s(t *testing.T) {
+func deactivatedTestUint16s(t *testing.T) {
 	// This should panic on 32-bit machine
 	/*
 		countBytes := []byte{0xff, 0xff, 0xff, 0xff}


### PR DESCRIPTION
… zone  we can reopen this when we decide https://github.com/tendermint/go-wire/issues/56 or make the length-prefixed encoder