### PR TITLE
new Marshal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.3 (Mar 2, 2018)
+
+FEATURES:
+ - new Marshal API in preparation for major upgrade: MarshalBinary, UnmarshalBinary, MarshalJSON, UnmarshalJSON
+
 ## 0.7.2 (Dec 5, 2017)
 
 IMPROVEMENTS:

--- a/util.go
+++ b/util.go
@@ -10,6 +10,40 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
+//-------------------------------------------------------
+// New go-wire API
+
+func MarshalBinary(o interface{}) ([]byte, error) {
+	w, n, err := new(bytes.Buffer), new(int), new(error)
+	WriteBinary(o, w, n, err)
+	if *err != nil {
+		return nil, *err
+	}
+	return w.Bytes(), nil
+}
+
+func UnmarshalBinary(bz []byte, ptr interface{}) error {
+	r, n, err := bytes.NewBuffer(bz), new(int), new(error)
+	ReadBinaryPtr(ptr, r, len(bz), n, err)
+	return *err
+}
+
+func MarshalJSON(o interface{}) ([]byte, error) {
+	w, n, err := new(bytes.Buffer), new(int), new(error)
+	WriteJSON(o, w, n, err)
+	if *err != nil {
+		return nil, *err
+	}
+	return w.Bytes(), nil
+}
+
+func UnmarshalJSON(bz []byte, ptr interface{}) (err error) {
+	ReadJSONPtr(ptr, bz, &err)
+	return
+}
+
+//-------------------------------------------------------
+
 func BinaryBytes(o interface{}) []byte {
 	w, n, err := new(bytes.Buffer), new(int), new(error)
 	WriteBinary(o, w, n, err)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package wire
 
-const Version = "0.7.2"
+const Version = "0.7.3"


### PR DESCRIPTION
Support the new go-wire API so we can iteratively upgrade consumers without breaking everything at once.
