### PR TITLE
fix and test distracting invalid null bytes trim

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -546,15 +546,10 @@ func nameToPrefix(name string) (pb PrefixBytes) {
 func nameToDisfix(name string) (db DisambBytes, pb PrefixBytes) {
 	hasher := sha256.New()
 	hasher.Write([]byte(name))
-	bz := hasher.Sum(nil)
-	for bz[0] == 0x00 {
-		bz = bz[1:]
-	}
+	bz := trimNullPrefixBytes(hasher.Sum(nil))
 	copy(db[:], bz[0:3])
 	bz = bz[3:]
-	for bz[0] == 0x00 {
-		bz = bz[1:]
-	}
+	bz = trimNullPrefixBytes(bz)
 	copy(pb[:], bz[0:4])
 	// Drop the last 3 bits to make room for the Typ3.
 	pb[3] &= 0xF8
@@ -565,4 +560,8 @@ func toDisfix(db DisambBytes, pb PrefixBytes) (df DisfixBytes) {
 	copy(df[0:3], db[0:3])
 	copy(df[3:7], pb[0:4])
 	return
+}
+
+func trimNullPrefixBytes(b []byte) []byte {
+	return bytes.TrimLeftFunc(b, func(r rune) bool { return r == 0x00 })
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,25 @@
+package wire
+
+// Add tests for internal utils and helpers here.
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTrimNullPrefixBytes(t *testing.T) {
+	tests := []struct {
+		in   []byte
+		want []byte
+	}{
+		{in: []byte{0x00, 0x00, 0x00, 0x00}, want: []byte{}},
+		{in: []byte{0x00, 0x00, 0x01, 0x00}, want: []byte{0x01, 0x00}},
+		{in: []byte{0x10, 0x00, 0x01, 0x00}, want: []byte{0x10, 0x00, 0x01, 0x00}},
+	}
+
+	for i, tt := range tests {
+		if got, want := trimNullPrefixBytes(tt.in), tt.want; !bytes.Equal(got, want) {
+			t.Errorf("#%d: got=(% X) want=(% X)", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #88

The previous trimming code was
```go
for bz[0] == 0x00 {
    bz = bz[1:]
}
```
after being generated by a sha256 sum.

This code was flagged independently by both @veorq
and myself. @veorq analyzed and found that there
are about: 2^54 strings that'll trigger the panic
i.e. contain all zeros and cause a runtime panic.
If we process billions of names, the probability
is negligible.

Nonetheless this is code we shouldn't have in
the repo as it could get copied naively, it is slow too
plus it captured the attention of two independent auditors.

Fix this by using the stdlib's bytes.TrimLeft and also
include tests to lock this behavior in.