### PR TITLE
Implement DeepCopy() and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.8 (April 26, 2018)
+
+NEW FEATURES:
+ - DeepCopy() copies any Amino object (with support for .DeepCopy() and
+   .MarshalAmino/UnmarshalAmino().
+
 ## 0.9.7 (April 25, 2019)
 
 FEATURES:

--- a/amino.go
+++ b/amino.go
@@ -355,12 +355,3 @@ func (cdc *Codec) MarshalJSONIndent(o interface{}, prefix, indent string) ([]byt
 	}
 	return out.Bytes(), nil
 }
-
-//----------------------------------------
-// Misc.
-
-var (
-	jsonMarshalerType   = reflect.TypeOf(new(json.Marshaler)).Elem()
-	jsonUnmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
-	errorType           = reflect.TypeOf(new(error)).Elem()
-)

--- a/deep_copy.go
+++ b/deep_copy.go
@@ -1,0 +1,229 @@
+package amino
+
+import (
+	"fmt"
+	"reflect"
+)
+
+//----------------------------------------
+// DeepCopy
+
+func DeepCopy(o interface{}) (r interface{}) {
+	if o == nil {
+		return nil
+	}
+	src := reflect.ValueOf(o)
+	dst := reflect.New(src.Type()).Elem()
+	deepCopy(src, dst)
+	return dst.Interface()
+}
+
+func deepCopy(src, dst reflect.Value) {
+	if isTypedNilReflect(src) {
+		return
+	}
+	if callDeepCopy(src, dst) {
+		return
+	}
+	if callAminoCopy(src, dst) {
+		return
+	}
+	_deepCopy(src, dst)
+}
+
+func _deepCopy(src, dst reflect.Value) {
+
+	switch src.Kind() {
+	case reflect.Ptr:
+		cpy := reflect.New(src.Type().Elem())
+		_deepCopy(src.Elem(), cpy.Elem())
+		dst.Set(cpy)
+		return
+
+	case reflect.Interface:
+		deepCopy(src.Elem(), dst.Elem())
+		return
+
+	case reflect.Array:
+		switch src.Type().Elem().Kind() {
+		case reflect.Int64, reflect.Int32, reflect.Int16,
+			reflect.Int8, reflect.Int, reflect.Uint64,
+			reflect.Uint32, reflect.Uint16, reflect.Uint8,
+			reflect.Uint, reflect.Bool, reflect.Float64,
+			reflect.Float32, reflect.String:
+
+			reflect.Copy(dst, src)
+			return
+		default:
+			for i := 0; i < src.Type().Len(); i++ {
+				esrc := src.Index(i)
+				edst := dst.Index(i)
+				deepCopy(esrc, edst)
+			}
+			return
+		}
+
+	case reflect.Slice:
+		switch src.Type().Elem().Kind() {
+		case reflect.Int64, reflect.Int32, reflect.Int16,
+			reflect.Int8, reflect.Int, reflect.Uint64,
+			reflect.Uint32, reflect.Uint16, reflect.Uint8,
+			reflect.Uint, reflect.Bool, reflect.Float64,
+			reflect.Float32, reflect.String:
+
+			cpy := reflect.MakeSlice(
+				src.Type(), src.Len(), src.Len())
+			reflect.Copy(cpy, src)
+			dst.Set(src)
+			return
+		default:
+			cpy := reflect.MakeSlice(
+				src.Type(), src.Len(), src.Len())
+			for i := 0; i < src.Len(); i++ {
+				esrc := src.Index(i)
+				ecpy := cpy.Index(i)
+				deepCopy(esrc, ecpy)
+			}
+			dst.Set(src)
+			return
+		}
+
+	case reflect.Struct:
+		switch src.Type() {
+		case timeType:
+			dst.Set(src)
+			return
+		default:
+			for i := 0; i < src.NumField(); i++ {
+				if !isExported(src.Type().Field(i)) {
+					continue // field is unexported
+				}
+				srcf := src.Field(i)
+				dstf := dst.Field(i)
+				deepCopy(srcf, dstf)
+			}
+			return
+		}
+
+	case reflect.Map:
+		cpy := reflect.MakeMapWithSize(src.Type(), src.Len())
+		keys := src.MapKeys()
+		for _, key := range keys {
+			val := src.MapIndex(key)
+			cpy.SetMapIndex(key, val)
+		}
+		dst.Set(cpy)
+		return
+
+	// Primitive types
+	case reflect.Int64, reflect.Int32, reflect.Int16,
+		reflect.Int8, reflect.Int:
+		dst.SetInt(src.Int())
+	case reflect.Uint64, reflect.Uint32, reflect.Uint16,
+		reflect.Uint8, reflect.Uint:
+		dst.SetUint(src.Uint())
+	case reflect.Bool:
+		dst.SetBool(src.Bool())
+	case reflect.Float64, reflect.Float32:
+		dst.SetFloat(src.Float())
+	case reflect.String:
+		dst.SetString(src.String())
+
+	default:
+		panic(fmt.Sprintf("unsupported type %v", src.Kind()))
+	}
+
+	return
+}
+
+//----------------------------------------
+// misc.
+
+// Call .DeepCopy() method if possible.
+func callDeepCopy(src, dst reflect.Value) bool {
+	dc := src.MethodByName("DeepCopy")
+	if !dc.IsValid() {
+		return false
+	}
+	if dc.Type().NumIn() != 0 {
+		return false
+	}
+	if dc.Type().NumOut() != 1 {
+		return false
+	}
+	otype := dc.Type().Out(0)
+	if dst.Kind() == reflect.Ptr &&
+		dst.Type().Elem() == otype {
+		cpy := reflect.New(dst.Type().Elem())
+		out := dc.Call(nil)[0]
+		cpy.Elem().Set(out)
+		dst.Set(cpy)
+		return true
+	}
+	if dst.Type() == otype {
+		out := dc.Call(nil)[0]
+		dst.Set(out)
+		return true
+	}
+	return false
+}
+
+// Call .MarshalAmino() and .UnmarshalAmino to copy if possible.
+// CONTRACT: src and dst are of equal types.
+func callAminoCopy(src, dst reflect.Value) bool {
+	if src.Type() != dst.Type() {
+		panic("should not happen")
+	}
+	if src.Kind() == reflect.Ptr {
+		cpy := reflect.New(src.Type().Elem())
+		dst.Set(cpy)
+	} else if src.CanAddr() {
+		if !dst.CanAddr() {
+			panic("should not happen")
+		}
+		src = src.Addr()
+		dst = dst.Addr()
+	} else {
+		return false
+	}
+	if !canAminoCopy(src) {
+		return false
+	}
+	cpy := reflect.New(src.Type().Elem())
+	dst.Set(cpy)
+	ma := src.MethodByName("MarshalAmino")
+	ua := dst.MethodByName("UnmarshalAmino")
+	out := ma.Call(nil)[0]
+	ua.Call([]reflect.Value{out})
+	return true
+}
+
+func canAminoCopy(rv reflect.Value) bool {
+	if !rv.MethodByName("UnmarshalAmino").IsValid() {
+		return false
+	}
+	ua := rv.MethodByName("UnmarshalAmino")
+	if !ua.IsValid() {
+		return false
+	}
+	if ua.Type().NumIn() != 1 {
+		return false
+	}
+	if ua.Type().NumOut() != 0 {
+		return false
+	}
+	ma := rv.MethodByName("MarshalAmino")
+	if !ma.IsValid() {
+		return false
+	}
+	if ma.Type().NumIn() != 0 {
+		return false
+	}
+	if ma.Type().NumOut() != 1 {
+		return false
+	}
+	if ua.Type().In(0) != ma.Type().Out(0) {
+		return false
+	}
+	return true
+}

--- a/deep_copy.go
+++ b/deep_copy.go
@@ -19,7 +19,7 @@ func DeepCopy(o interface{}) (r interface{}) {
 }
 
 func deepCopy(src, dst reflect.Value) {
-	if isTypedNilReflect(src) {
+	if isNil(src) {
 		return
 	}
 	if callDeepCopy(src, dst) {
@@ -41,7 +41,9 @@ func _deepCopy(src, dst reflect.Value) {
 		return
 
 	case reflect.Interface:
-		deepCopy(src.Elem(), dst.Elem())
+		cpy := reflect.New(src.Elem().Type())
+		deepCopy(src.Elem(), cpy.Elem())
+		dst.Set(cpy.Elem())
 		return
 
 	case reflect.Array:

--- a/deep_copy_test.go
+++ b/deep_copy_test.go
@@ -90,3 +90,23 @@ func TestDeepCopyFoo7(t *testing.T) {
 	dcf2 := amino.DeepCopy(dcf1).(*DCFoo7)
 	assert.Equal(t, "good", dcf2.a)
 }
+
+type DCInterface1 struct {
+	Foo interface{}
+}
+
+func TestDeepCopyInterface1(t *testing.T) {
+	dci1 := DCInterface1{Foo: nil}
+	dci2 := amino.DeepCopy(dci1).(DCInterface1)
+	assert.Nil(t, dci2.Foo)
+}
+
+type DCInterface2 struct {
+	Foo interface{}
+}
+
+func TestDeepCopyInterface2(t *testing.T) {
+	dci1 := DCInterface1{Foo: "foo"}
+	dci2 := amino.DeepCopy(dci1).(DCInterface1)
+	assert.Equal(t, "foo", dci2.Foo)
+}

--- a/deep_copy_test.go
+++ b/deep_copy_test.go
@@ -1,0 +1,92 @@
+package amino_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	amino "github.com/tendermint/go-amino"
+)
+
+type DCFoo1 struct{ a string }
+
+func newDCFoo1(a string) *DCFoo1            { return &DCFoo1{a: a} }
+func (dcf *DCFoo1) MarshalAmino() string    { return dcf.a }
+func (dcf *DCFoo1) UnmarshalAmino(s string) { dcf.a = s }
+
+func TestDeepCopyFoo1(t *testing.T) {
+	dcf1 := newDCFoo1("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo1)
+	assert.Equal(t, "foobar", dcf2.a)
+}
+
+type DCFoo2 struct{ a string }
+
+func newDCFoo2(a string) *DCFoo2            { return &DCFoo2{a: a} }
+func (dcf DCFoo2) MarshalAmino() string     { return dcf.a } // Non-pointer receiver
+func (dcf *DCFoo2) UnmarshalAmino(s string) { dcf.a = s }
+
+func TestDeepCopyFoo2(t *testing.T) {
+	dcf1 := newDCFoo2("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo2)
+	assert.Equal(t, "foobar", dcf2.a)
+}
+
+type DCFoo3 struct{ a string }
+
+func newDCFoo3(a string) *DCFoo3            { return &DCFoo3{a: a} }
+func (dcf DCFoo3) MarshalAmino() string     { return dcf.a }
+func (dcf *DCFoo3) UnmarshalAmino(s []byte) { dcf.a = string(s) } // Mismatch type
+
+func TestDeepCopyFoo3(t *testing.T) {
+	dcf1 := newDCFoo3("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo3)
+	assert.Equal(t, "", dcf2.a)
+}
+
+type DCFoo4 struct{ a string }
+
+func newDCFoo4(a string) *DCFoo4            { return &DCFoo4{a: a} }
+func (dcf *DCFoo4) DeepCopy() *DCFoo4       { return &DCFoo4{"good"} }
+func (dcf DCFoo4) MarshalAmino() string     { return dcf.a }
+func (dcf *DCFoo4) UnmarshalAmino(s string) { dcf.a = string(s) } // Mismatch type
+
+func TestDeepCopyFoo4(t *testing.T) {
+	dcf1 := newDCFoo4("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo4)
+	assert.Equal(t, "good", dcf2.a)
+}
+
+type DCFoo5 struct{ a string }
+
+func newDCFoo5(a string) *DCFoo5            { return &DCFoo5{a: a} }
+func (dcf DCFoo5) DeepCopy() DCFoo5         { return DCFoo5{"good"} }
+func (dcf DCFoo5) MarshalAmino() string     { return dcf.a }
+func (dcf *DCFoo5) UnmarshalAmino(s string) { dcf.a = string(s) } // Mismatch type
+
+func TestDeepCopyFoo5(t *testing.T) {
+	dcf1 := newDCFoo5("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo5)
+	assert.Equal(t, "good", dcf2.a)
+}
+
+type DCFoo6 struct{ a string }
+
+func newDCFoo6(a string) *DCFoo6     { return &DCFoo6{a: a} }
+func (dcf *DCFoo6) DeepCopy() DCFoo6 { return DCFoo6{"good"} }
+
+func TestDeepCopyFoo6(t *testing.T) {
+	dcf1 := newDCFoo6("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo6)
+	assert.Equal(t, "good", dcf2.a)
+}
+
+type DCFoo7 struct{ a string }
+
+func newDCFoo7(a string) *DCFoo7     { return &DCFoo7{a: a} }
+func (dcf DCFoo7) DeepCopy() *DCFoo7 { return &DCFoo7{"good"} }
+
+func TestDeepCopyFoo7(t *testing.T) {
+	dcf1 := newDCFoo7("foobar")
+	dcf2 := amino.DeepCopy(dcf1).(*DCFoo7)
+	assert.Equal(t, "good", dcf2.a)
+}

--- a/deep_copy_test.go
+++ b/deep_copy_test.go
@@ -1,6 +1,7 @@
 package amino_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,9 +10,9 @@ import (
 
 type DCFoo1 struct{ a string }
 
-func newDCFoo1(a string) *DCFoo1            { return &DCFoo1{a: a} }
-func (dcf *DCFoo1) MarshalAmino() string    { return dcf.a }
-func (dcf *DCFoo1) UnmarshalAmino(s string) { dcf.a = s }
+func newDCFoo1(a string) *DCFoo1                  { return &DCFoo1{a: a} }
+func (dcf *DCFoo1) MarshalAmino() (string, error) { return dcf.a, nil }
+func (dcf *DCFoo1) UnmarshalAmino(s string) error { dcf.a = s; return nil }
 
 func TestDeepCopyFoo1(t *testing.T) {
 	dcf1 := newDCFoo1("foobar")
@@ -21,9 +22,9 @@ func TestDeepCopyFoo1(t *testing.T) {
 
 type DCFoo2 struct{ a string }
 
-func newDCFoo2(a string) *DCFoo2            { return &DCFoo2{a: a} }
-func (dcf DCFoo2) MarshalAmino() string     { return dcf.a } // Non-pointer receiver
-func (dcf *DCFoo2) UnmarshalAmino(s string) { dcf.a = s }
+func newDCFoo2(a string) *DCFoo2                  { return &DCFoo2{a: a} }
+func (dcf DCFoo2) MarshalAmino() (string, error)  { return dcf.a, nil } // non-pointer receiver
+func (dcf *DCFoo2) UnmarshalAmino(s string) error { dcf.a = s; return nil }
 
 func TestDeepCopyFoo2(t *testing.T) {
 	dcf1 := newDCFoo2("foobar")
@@ -33,9 +34,9 @@ func TestDeepCopyFoo2(t *testing.T) {
 
 type DCFoo3 struct{ a string }
 
-func newDCFoo3(a string) *DCFoo3            { return &DCFoo3{a: a} }
-func (dcf DCFoo3) MarshalAmino() string     { return dcf.a }
-func (dcf *DCFoo3) UnmarshalAmino(s []byte) { dcf.a = string(s) } // Mismatch type
+func newDCFoo3(a string) *DCFoo3                  { return &DCFoo3{a: a} }
+func (dcf DCFoo3) MarshalAmino() (string, error)  { return dcf.a, nil }
+func (dcf *DCFoo3) UnmarshalAmino(s []byte) error { dcf.a = string(s); return nil } // mismatch type
 
 func TestDeepCopyFoo3(t *testing.T) {
 	dcf1 := newDCFoo3("foobar")
@@ -45,10 +46,10 @@ func TestDeepCopyFoo3(t *testing.T) {
 
 type DCFoo4 struct{ a string }
 
-func newDCFoo4(a string) *DCFoo4            { return &DCFoo4{a: a} }
-func (dcf *DCFoo4) DeepCopy() *DCFoo4       { return &DCFoo4{"good"} }
-func (dcf DCFoo4) MarshalAmino() string     { return dcf.a }
-func (dcf *DCFoo4) UnmarshalAmino(s string) { dcf.a = string(s) } // Mismatch type
+func newDCFoo4(a string) *DCFoo4                  { return &DCFoo4{a: a} }
+func (dcf *DCFoo4) DeepCopy() *DCFoo4             { return &DCFoo4{"good"} }
+func (dcf DCFoo4) MarshalAmino() (string, error)  { return dcf.a, nil }
+func (dcf *DCFoo4) UnmarshalAmino(s string) error { dcf.a = string(s); return nil } // mismatch type
 
 func TestDeepCopyFoo4(t *testing.T) {
 	dcf1 := newDCFoo4("foobar")
@@ -58,10 +59,10 @@ func TestDeepCopyFoo4(t *testing.T) {
 
 type DCFoo5 struct{ a string }
 
-func newDCFoo5(a string) *DCFoo5            { return &DCFoo5{a: a} }
-func (dcf DCFoo5) DeepCopy() DCFoo5         { return DCFoo5{"good"} }
-func (dcf DCFoo5) MarshalAmino() string     { return dcf.a }
-func (dcf *DCFoo5) UnmarshalAmino(s string) { dcf.a = string(s) } // Mismatch type
+func newDCFoo5(a string) *DCFoo5                  { return &DCFoo5{a: a} }
+func (dcf DCFoo5) DeepCopy() DCFoo5               { return DCFoo5{"good"} }
+func (dcf DCFoo5) MarshalAmino() (string, error)  { return dcf.a, nil }
+func (dcf *DCFoo5) UnmarshalAmino(s string) error { dcf.a = string(s); return nil } // mismatch type
 
 func TestDeepCopyFoo5(t *testing.T) {
 	dcf1 := newDCFoo5("foobar")
@@ -89,6 +90,28 @@ func TestDeepCopyFoo7(t *testing.T) {
 	dcf1 := newDCFoo7("foobar")
 	dcf2 := amino.DeepCopy(dcf1).(*DCFoo7)
 	assert.Equal(t, "good", dcf2.a)
+}
+
+type DCFoo8 struct{ a string }
+
+func newDCFoo8(a string) *DCFoo8                  { return &DCFoo8{a: a} }
+func (dcf DCFoo8) MarshalAmino() (string, error)  { return "", errors.New("uh oh") } // error
+func (dcf *DCFoo8) UnmarshalAmino(s string) error { dcf.a = string(s); return nil }
+
+func TestDeepCopyFoo8(t *testing.T) {
+	dcf1 := newDCFoo8("foobar")
+	assert.Panics(t, func() { amino.DeepCopy(dcf1) })
+}
+
+type DCFoo9 struct{ a string }
+
+func newDCFoo9(a string) *DCFoo9                  { return &DCFoo9{a: a} }
+func (dcf DCFoo9) MarshalAmino() (string, error)  { return dcf.a, nil }
+func (dcf *DCFoo9) UnmarshalAmino(s string) error { return errors.New("uh oh") } // error
+
+func TestDeepCopyFoo9(t *testing.T) {
+	dcf1 := newDCFoo9("foobar")
+	assert.Panics(t, func() { amino.DeepCopy(dcf1) })
 }
 
 type DCInterface1 struct {

--- a/reflect.go
+++ b/reflect.go
@@ -87,6 +87,15 @@ func isVoid(rv reflect.Value) (erv reflect.Value, isVoid bool) {
 	}
 }
 
+func isTypedNilReflect(rv reflect.Value) bool {
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
 // constructConcreteType creates the concrete value as
 // well as the corresponding settable value for it.
 // Return irvSet which should be set on caller's interface rv.

--- a/reflect.go
+++ b/reflect.go
@@ -1,6 +1,7 @@
 package amino
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -10,9 +11,14 @@ import (
 // Constants
 
 const printLog = false
-
 const RFC3339Millis = "2006-01-02T15:04:05.000Z" // forced microseconds
-var timeType = reflect.TypeOf(time.Time{})
+
+var (
+	timeType            = reflect.TypeOf(time.Time{})
+	jsonMarshalerType   = reflect.TypeOf(new(json.Marshaler)).Elem()
+	jsonUnmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
+	errorType           = reflect.TypeOf(new(error)).Elem()
+)
 
 //----------------------------------------
 // encode: see binary-encode.go and json-encode.go

--- a/reflect.go
+++ b/reflect.go
@@ -87,9 +87,9 @@ func isVoid(rv reflect.Value) (erv reflect.Value, isVoid bool) {
 	}
 }
 
-func isTypedNilReflect(rv reflect.Value) bool {
+func isNil(rv reflect.Value) bool {
 	switch rv.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice:
 		return rv.IsNil()
 	default:
 		return false

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package amino
 
 // Version
-const Version = "0.9.7"
+const Version = "0.9.8"


### PR DESCRIPTION
DeepCopy() respects `<object>.DeepCopy() <any>` as well as `<object>.MarshalAmino() <any>`/`<*object>.UnmarshalAmino(<any>)`.