### PR TITLE
Jae/jsontypename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.10 (May 10, 2018)
+
+BREAKING CHANGE:
+
+ - Amino:JSON encoding of interfaces use the registered concrete type name, not the disfix bytes.
+
 ## 0.9.9 (May 1, 2018)
 
 BUG FIXES:

--- a/json-decode.go
+++ b/json-decode.go
@@ -38,7 +38,7 @@ func (cdc *Codec) decodeReflectJSON(bz []byte, info *TypeInfo, rv reflect.Value,
 			return
 		}
 		if info.Name != name {
-			err = fmt.Errorf("Expected type name %s but got %s",
+			err = fmt.Errorf("expected type name %s but got %s",
 				info.Name, name)
 			return
 		}
@@ -500,7 +500,7 @@ func decodeInterfaceJSON(bz []byte) (name string, data []byte, err error) {
 	dfw := new(disfixWrapper)
 	err = json.Unmarshal(bz, dfw)
 	if err != nil {
-		err = fmt.Errorf("Cannot parse disfix JSON wrapper: %v", err)
+		err = fmt.Errorf("cannot parse disfix JSON wrapper: %v", err)
 		return
 	}
 
@@ -513,7 +513,7 @@ func decodeInterfaceJSON(bz []byte) (name string, data []byte, err error) {
 
 	// Get data.
 	if len(dfw.Data) == 0 {
-		err = errors.New("Interface JSON wrapper should have non-empty value field")
+		err = errors.New("interface JSON wrapper should have non-empty value field")
 		return
 	}
 	data = dfw.Data

--- a/json-encode.go
+++ b/json-encode.go
@@ -33,8 +33,7 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 	// Write the disfix wrapper if it is a registered concrete type.
 	if info.Registered {
 		// Part 1:
-		disfix := toDisfix(info.Disamb, info.Prefix)
-		err = writeStr(w, _fmt(`{"type":"%X","value":`, disfix))
+		err = writeStr(w, _fmt(`{"type":"%s","value":`, info.Name))
 		if err != nil {
 			return
 		}
@@ -184,10 +183,9 @@ func (cdc *Codec) encodeReflectJSONInterface(w io.Writer, iinfo *TypeInfo, rv re
 		return
 	}
 
-	// Write disfix wrapper.
+	// Write interface wrapper.
 	// Part 1:
-	disfix := toDisfix(cinfo.Disamb, cinfo.Prefix)
-	err = writeStr(w, _fmt(`{"type":"%X","value":`, disfix))
+	err = writeStr(w, _fmt(`{"type":"%s","value":`, cinfo.Name))
 	if err != nil {
 		return
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -36,8 +36,8 @@ func TestMarshalJSON(t *testing.T) {
 		{&noExportedFields{a: 10, b: "foo"}, "{}", ""},
 		{nil, "null", ""},
 		{&oneExportedField{}, `{"A":""}`, ""},
-		{Vehicle(Car("Tesla")), `{"type":"2B2961A431B238","value":"Tesla"}`, ""},
-		{Car("Tesla"), `{"type":"2B2961A431B238","value":"Tesla"}`, ""},
+		{Vehicle(Car("Tesla")), `{"type":"car","value":"Tesla"}`, ""},
+		{Car("Tesla"), `{"type":"car","value":"Tesla"}`, ""},
 		{&oneExportedField{A: "Z"}, `{"A":"Z"}`, ""},
 		{[]string{"a", "bc"}, `["a","bc"]`, ""},
 		{[]interface{}{"a", "bc", 10, 10.93, 1e3}, ``, "Unregistered"},
@@ -64,19 +64,19 @@ func TestMarshalJSON(t *testing.T) {
 		},
 		{
 			Transport{},
-			`{"type":"AEB127E121A6B0","value":{"Vehicle":null,"Capacity":0}}`, "",
+			`{"type":"our/transport","value":{"Vehicle":null,"Capacity":0}}`, "",
 		},
 		{
 			Transport{Vehicle: Car("Bugatti")},
-			`{"type":"AEB127E121A6B0","value":{"Vehicle":{"type":"2B2961A431B238","value":"Bugatti"},"Capacity":0}}`, "",
+			`{"type":"our/transport","value":{"Vehicle":{"type":"car","value":"Bugatti"},"Capacity":0}}`, "",
 		},
 		{
 			BalanceSheet{Assets: []Asset{Car("Corolla"), insurancePlan(1e7)}},
-			`{"assets":[{"type":"2B2961A431B238","value":"Corolla"},{"type":"7DF0BC76182A18","value":10000000}]}`, "",
+			`{"assets":[{"type":"car","value":"Corolla"},{"type":"insuranceplan","value":10000000}]}`, "",
 		},
 		{
 			Transport{Vehicle: Boat("Poseidon"), Capacity: 1789},
-			`{"type":"AEB127E121A6B0","value":{"Vehicle":{"type":"25CDB46D8D2110","value":"Poseidon"},"Capacity":1789}}`, "",
+			`{"type":"our/transport","value":{"Vehicle":{"type":"boat","value":"Poseidon"},"Capacity":1789}}`, "",
 		},
 		{
 			withCustomMarshaler{A: &aPointerField{Foo: intPtr(12)}, F: customJSONMarshaler(10)},
@@ -260,10 +260,10 @@ func TestUnmarshalJSON(t *testing.T) {
 			`{"null"}`, new(int), nil, "invalid character",
 		},
 		{
-			`{"type":"AEB127E121A6B0","value":{"Vehicle":null,"Capacity":0}}`, new(Transport), new(Transport), "",
+			`{"type":"our/transport","value":{"Vehicle":null,"Capacity":0}}`, new(Transport), new(Transport), "",
 		},
 		{
-			`{"type":"AEB127E121A6B0","value":{"Vehicle":{"type":"2B2961A431B238","value":"Bugatti"},"Capacity":10}}`,
+			`{"type":"our/transport","value":{"Vehicle":{"type":"car","value":"Bugatti"},"Capacity":10}}`,
 			new(Transport),
 			&Transport{
 				Vehicle:  Car("Bugatti"),
@@ -271,7 +271,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			}, "",
 		},
 		{
-			`{"type":"2B2961A431B238","value":"Bugatti"}`, new(Car), func() *Car { c := Car("Bugatti"); return &c }(), "",
+			`{"type":"car","value":"Bugatti"}`, new(Car), func() *Car { c := Car("Bugatti"); return &c }(), "",
 		},
 		{
 			`[1, 2, 3]`, new([]int), func() interface{} {
@@ -573,7 +573,7 @@ func TestMarshalJSONIndent(t *testing.T) {
 	obj := Car("Tesla")
 	indent := "  "
 	expected := fmt.Sprintf(`{
-%s"type": "2B2961A431B238",
+%s"type": "car",
 %s"value": "Tesla"
 }`, indent, indent)
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -266,7 +266,7 @@ func TestCodecJSONRegister8(t *testing.T) {
 	// But that's OK, JSON still writes the disfix bytes by default.
 	bz, err := cdc.MarshalJSON(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte(`{"type":"43FAF453372100","value":"MDEyMw=="}`),
+	assert.Equal(t, []byte(`{"type":"Concrete3","value":"MDEyMw=="}`),
 		bz, "Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package amino
 
 // Version
-const Version = "0.9.9"
+const Version = "0.9.10"


### PR DESCRIPTION
## 0.9.10 (May 10, 2018)

BREAKING CHANGE:

 - Amino:JSON encoding of interfaces use the registered concrete type name, not the disfix bytes.
