### PR TITLE
Improve usability / readability of error messages

### DIFF
--- a/binary-decode.go
+++ b/binary-decode.go
@@ -677,12 +677,12 @@ func (cdc *Codec) decodeReflectBinaryStruct(bz []byte, info *TypeInfo, rv reflec
 			// So in the future, this may not match,
 			// so we will need to remove this sanity check.
 			if field.BinFieldNum != fieldNum {
-				err = errors.New(fmt.Sprintf("Expected field number %v, got %v", field.BinFieldNum, fieldNum))
+				err = errors.New(fmt.Sprintf("expected field number %v, got %v", field.BinFieldNum, fieldNum))
 				return
 			}
 			typWanted := typeToTyp4(field.Type, field.FieldOptions).Typ3()
 			if typ != typWanted {
-				err = errors.New(fmt.Sprintf("Expected field type %X, got %X", typWanted, typ))
+				err = errors.New(fmt.Sprintf("expected field type %v, got %v", typWanted, typ))
 				return
 			}
 
@@ -702,7 +702,7 @@ func (cdc *Codec) decodeReflectBinaryStruct(bz []byte, info *TypeInfo, rv reflec
 			return
 		}
 		if typ != Typ3_StructTerm {
-			err = errors.New(fmt.Sprintf("Expected StructTerm typ3 byte, got %X", typ))
+			err = errors.New(fmt.Sprintf("expected StructTerm typ3 byte, got %v", typ))
 			return
 		}
 		return
@@ -780,7 +780,7 @@ func decodeTyp4AndCheck(rt reflect.Type, bz []byte, opts FieldOptions) (ptr bool
 	}
 	var typWanted = typeToTyp4(rt, opts)
 	if typWanted != typ {
-		err = errors.New(fmt.Sprintf("Typ4 mismatch.  Expected %X, got %X", typWanted, typ))
+		err = errors.New(fmt.Sprintf("Typ4 mismatch. Expected %v, got %v", typWanted, typ))
 		return
 	}
 	ptr = (typ & 0x08) != 0
@@ -806,7 +806,7 @@ func decodeTyp4(bz []byte) (typ Typ4, n int, err error) {
 func checkTyp3(rt reflect.Type, typ Typ3, opts FieldOptions) (err error) {
 	typWanted := typeToTyp3(rt, opts)
 	if typ != typWanted {
-		err = fmt.Errorf("Typ3 mismatch.  Expected %X, got %X", typWanted, typ)
+		err = fmt.Errorf("Typ3 mismatch. Expected %v, got %v", typWanted, typ)
 	}
 	return
 }
@@ -842,6 +842,6 @@ func decodeNumNilBytes(bz []byte) (numNil int64, n int, err error) {
 		numNil, n = 1, 1
 		return
 	}
-	n, err = 0, fmt.Errorf("Unexpected nil byte %X (sparse lists not supported)", bz[0])
+	n, err = 0, fmt.Errorf("unexpected nil byte, want: either '0x00' or '0x01' got: %X (sparse lists not supported)", bz[0])
 	return
 }

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -408,7 +408,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 // Write field key.
 func encodeFieldNumberAndTyp3(w io.Writer, num uint32, typ Typ3) (err error) {
 	if (typ & 0xF8) != 0 {
-		panic(fmt.Sprintf("invalid Typ3 byte %X", typ))
+		panic(fmt.Sprintf("invalid Typ3 byte %v", typ))
 	}
 	if num < 0 || num > (1<<29-1) {
 		panic(fmt.Sprintf("invalid field number %v", num))

--- a/codec.go
+++ b/codec.go
@@ -294,7 +294,7 @@ func (cdc *Codec) getTypeInfoFromPrefix_rlock(iinfo *TypeInfo, pb PrefixBytes) (
 		return
 	}
 	if len(infos) > 1 {
-		err = fmt.Errorf("Conflicting concrete types registered for %X: e.g. %v and %v.", pb, infos[0].Type, infos[1].Type)
+		err = fmt.Errorf("conflicting concrete types registered for %X: e.g. %v and %v", pb, infos[0].Type, infos[1].Type)
 		return
 	}
 	info = infos[0]

--- a/decoder.go
+++ b/decoder.go
@@ -200,11 +200,11 @@ func DecodeTime(bz []byte) (t time.Time, n int, err error) {
 			return
 		}
 		if fieldNum != 1 {
-			err = fmt.Errorf("Expected field number 1, got %v", fieldNum)
+			err = fmt.Errorf("expected field number 1, got %v", fieldNum)
 			return
 		}
 		if typ != Typ3_8Byte {
-			err = fmt.Errorf("Expected Typ3 bytes <8Bytes> for time field #1, got %X", typ)
+			err = fmt.Errorf("expected Typ3 bytes <8Bytes> for time field #1, got %v", typ)
 			return
 		}
 	}
@@ -222,11 +222,11 @@ func DecodeTime(bz []byte) (t time.Time, n int, err error) {
 			return
 		}
 		if fieldNum != 2 {
-			err = fmt.Errorf("Expected field number 2, got %v", fieldNum)
+			err = fmt.Errorf("expected field number 2, got %v", fieldNum)
 			return
 		}
 		if typ != Typ3_4Byte {
-			err = fmt.Errorf("Expected Typ3 bytes <4Byte> for time field #2, got %X", typ)
+			err = fmt.Errorf("expected Typ3 bytes <4Byte> for time field #2, got %v", typ)
 			return
 		}
 	}
@@ -238,7 +238,7 @@ func DecodeTime(bz []byte) (t time.Time, n int, err error) {
 	}
 	// Validation check.
 	if nsec < 0 || 999999999 < nsec {
-		err = fmt.Errorf("Invalid time, nanoseconds out of bounds %v", nsec)
+		err = fmt.Errorf("invalid time, nanoseconds out of bounds %v", nsec)
 		return
 	}
 	{ // Expect "StructTerm" Typ3 byte.
@@ -248,7 +248,7 @@ func DecodeTime(bz []byte) (t time.Time, n int, err error) {
 			return
 		}
 		if typ != Typ3_StructTerm {
-			err = errors.New(fmt.Sprintf("Expected StructTerm Typ3 byte for time, got %X", typ))
+			err = errors.New(fmt.Sprintf("expected StructTerm Typ3 byte for time, got %v", typ))
 			return
 		}
 	}


### PR DESCRIPTION
- use human readable representation of typ3 / typ4 where possible
- non-capitalized error messages (see: https://github.com/golang/go/wiki/CodeReviewComments#error-strings)

resolves #145