### PR TITLE
Basic backwards compatibility

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -274,7 +274,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 		return err
 	}
 	if n != len(bz) {
-		return fmt.Errorf("Unmarshal didn't read all bytes. Expected to read %v, only read %v", len(bz), n)
+		return fmt.Errorf("unmarshal didn't read all bytes. Expected to read %v, only read %v", len(bz), n)
 	}
 	return nil
 }

--- a/binary-decode.go
+++ b/binary-decode.go
@@ -95,7 +95,7 @@ func (cdc *Codec) _decodeReflectBinary(bz []byte, info *TypeInfo, rv reflect.Val
 		rv = rv.Elem()
 	}
 
-	// Handle override if a pointer to rv implements Unmarshal
+	// Handle override if a pointer to rv implements UnmarshalAmino.
 	if info.IsAminoUnmarshaler {
 		// First, decode repr instance from bytes.
 		rrv, rinfo := reflect.New(info.AminoUnmarshalReprType).Elem(), (*TypeInfo)(nil)

--- a/binary_test.go
+++ b/binary_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/go-amino"
+	"time"
 )
 
 func TestNilSliceEmptySlice(t *testing.T) {
@@ -63,8 +64,9 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 	type V2 struct {
 		String  string
 		String2 string
-		// new field in V2:
-		Int int
+		// new fields in V2:
+		Time time.Time
+		Int  int
 	}
 
 	type SomeStruct struct {
@@ -72,15 +74,15 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 	}
 
 	type V3 struct {
-		String string `json:"string"`
+		String string
 		// different from V1 starting here:
 		Int  int
 		Some SomeStruct
 	}
 
 	cdc := amino.NewCodec()
-
-	v2 := V2{String: "hi", String2: "cosmos", Int: 4}
+	notNow, _ := time.Parse("2006-01-02", "1934-11-09")
+	v2 := V2{String: "hi", String2: "cosmos", Time: notNow, Int: 4}
 	bz, err := cdc.MarshalBinaryBare(v2)
 	assert.Nil(t, err, "unexpected error while encoding V2: %v", err)
 

--- a/binary_test.go
+++ b/binary_test.go
@@ -74,7 +74,7 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 	type V3 struct {
 		String string `json:"string"`
 		// different from V1 starting here:
-		Int  int `json:"int"`
+		Int  int
 		Some SomeStruct
 	}
 
@@ -100,4 +100,50 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 
 	// we still expect that decoding worked to some extend (until above error occurred):
 	assert.Equal(t, v1, V1{"tender", "cosmos"})
+}
+
+func TestAppendedSomeBytesAfterStructTerm(t *testing.T) {
+	// like above test but we add some bytes and expect an error:
+	type V1 struct {
+		String  string
+		String2 string
+	}
+
+	type V2 struct {
+		String  string
+		String2 string
+		// new field in V2:
+		Int int
+	}
+
+	cdc := amino.NewCodec()
+
+	v2 := V2{String: "to the", String2: "cosmos", Int: 4}
+	bz, err := cdc.MarshalBinaryBare(v2)
+	assert.Nil(t, err, "unexpected error while encoding V2: %v", err)
+
+	bzOrig := bz
+	// just add some meaningless bytes:
+	bz = append(bz, []byte{0xde, 0xad, 0xbe, 0xef}...)
+	var v1 V1
+	err = cdc.UnmarshalBinaryBare(bz, &v1)
+	// expected: unmarshal didn't read all bytes. Expected to read 23, only read 19
+	assert.NotNil(t, err, "expected error %v", err)
+
+	assert.Equal(t, v1, V1{"to the", "cosmos"},
+		"backwards compatibility failed: didn't yield expected result ...")
+
+	// append a structTerm:
+	bz = append(bzOrig, byte(amino.Typ3_StructTerm))
+
+	err = cdc.UnmarshalBinaryBare(bz, &v1)
+	// expected: unmarshal didn't read all bytes. Expected to read 20, only read 19
+	assert.NotNil(t, err, "expected error %v", err)
+
+	// append a struct start at the end (we should break before and not finish reading here):
+	bz = append(bzOrig, byte(amino.Typ3_Struct))
+
+	err = cdc.UnmarshalBinaryBare(bz, &v1)
+	// expected: unmarshal didn't read all bytes. Expected to read 20, only read 19
+	assert.NotNil(t, err, "expected error %v", err)
 }


### PR DESCRIPTION
To achieve basic backwards compatibility, we continue reading the passed buffer even if all fields were already read. We only check if what follows is valid amino encoding.

resolves #143 

this also includes changes of #153 which 
resolves #145