### PR TITLE
add possibility to pretty-print all (concrete) registered types 

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"sync"
@@ -246,6 +247,52 @@ func (cdc *Codec) Seal() *Codec {
 
 	cdc.sealed = true
 	return cdc
+}
+
+// PrintTypes writes all registered types in a markdown-style table.
+// The table's header is:
+//
+// | Type  | Name | Prefix | Notes |
+//
+// Where Type is the golang type name and Name is the name the type was registered with.
+func (cdc Codec) PrintTypes(out io.Writer) error {
+	cdc.mtx.RLock()
+	defer cdc.mtx.RUnlock()
+	// print header
+	if _, err := io.WriteString(out, "| Type | Name | Prefix | Notes |\n"); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(out, "| ---- | ---- | ------ | ----- |\n"); err != nil {
+		return err
+	}
+	// only print concrete types for now (if we want everything, we can iterate over the typeInfos map instead)
+	for _, i := range cdc.concreteInfos {
+		io.WriteString(out, "| ")
+		// TODO(ismail): optionally create a link to code on github:
+		if _, err := io.WriteString(out, i.Type.Name()); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, " | "); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, i.Name); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, " | "); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, fmt.Sprintf("0x%X", i.Prefix)); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, " | "); err != nil {
+			return err
+		}
+		// empty notes table data by default // TODO(ismail): make this configurable
+
+		io.WriteString(out, " |\n")
+	}
+	// finish table
+	return nil
 }
 
 //----------------------------------------


### PR DESCRIPTION
print registered types as a markdown table.
related to: 
https://github.com/tendermint/go-crypto/pull/110 and https://github.com/tendermint/go-crypto/issues/88

Example for go-crypto:

| Type | Name | Prefix | Length | Notes |
| ---- | ---- | ------ | ----- | ------ |
| PubKeyEd25519 | tendermint/PubKeyEd25519 | 0x1624DE62 | 0x20 |  |
| PubKeyLedgerEd25519 | tendermint/PubKeyLedgerEd25519 | 0x5C3453B2 | 0x20 |  |
| PubKeySecp256k1 | tendermint/PubKeySecp256k1 | 0xEB5AE982 | 0x21 |  |
| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288912 | 0x40 |  |
| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79A | 0x20 |  |
| PrivKeyLedgerSecp256k1 | tendermint/PrivKeyLedgerSecp256k1 | 0x10CAB393 | variable |  |
| PrivKeyLedgerEd25519 | tendermint/PrivKeyLedgerEd25519 | 0x0CFEEF9B | variable |  |
| SignatureEd25519 | tendermint/SignatureKeyEd25519 | 0x3DA1DB2A | 0x40 |  |
| SignatureSecp256k1 | tendermint/SignatureKeySecp256k1 | 0x16E1FEEA | variable |  |

golang code in go-crypto:
```golang
package crypto

import "os"

func ExamplePrintRegisteredTypes() {
	cdc.PrintTypes(os.Stdout)
	// Output: | Type | Name | Prefix | Length | Notes |
	//| ---- | ---- | ------ | ----- | ------ |
	//| PubKeyEd25519 | tendermint/PubKeyEd25519 | 0x1624DE62 | 0x20 |  |
	//| PubKeyLedgerEd25519 | tendermint/PubKeyLedgerEd25519 | 0x5C3453B2 | 0x20 |  |
	//| PubKeySecp256k1 | tendermint/PubKeySecp256k1 | 0xEB5AE982 | 0x21 |  |
	//| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288912 | 0x40 |  |
	//| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79A | 0x20 |  |
	//| PrivKeyLedgerSecp256k1 | tendermint/PrivKeyLedgerSecp256k1 | 0x10CAB393 | variable |  |
	//| PrivKeyLedgerEd25519 | tendermint/PrivKeyLedgerEd25519 | 0x0CFEEF9B | variable |  |
	//| SignatureEd25519 | tendermint/SignatureKeyEd25519 | 0x3DA1DB2A | 0x40 |  |
	//| SignatureSecp256k1 | tendermint/SignatureKeySecp256k1 | 0x16E1FEEA | variable |  |
}
```

/cc @ebuchman 