### PR TITLE
Proto3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This software implements Go bindings for the Amino encoding protocol.
 
-Amino is an object encoding specification. Think of it as an object-oriented
-Protobuf3 with native JSON support.
+Amino is an object encoding specification. It is a subset of Proto3 with
+an extension for interface support.
 
 The goal of the Amino encoding protocol is to bring parity into logic objects
 and persistence objects.
@@ -62,19 +62,6 @@ end up duplicating the structure in the Protobuf schema file and writing
 translators to and from your logic objects.  Amino can eliminate this extra
 duplication and help streamline development from inception to maturity.
 
-* In Protobuf3, [embedded message are `uvarint` byte-length prefixed]((https://github.com/tendermint/go-amino/wiki/aminoscan));
-  However, this makes the binary encoding naturally more inefficient, as bytes
-cannot simply be written to a memory array (buffer) in sequence without
-allocating a new buffer for each embedded message. Amino is encoded in such a
-way that the complete structure of the message (not just the top-level
-structure) can be determined by scanning the byte encoding without any type
-information other than what is available in the binary bytes. This makes
-encoding faster with no penalty when decoding.
-
-* In Protobuf3, lists are encoded as repeated field values.  This makes
-  decoding more expensive than necessary, since it is generally faster to know
-the length of a list/array to allocate prior to decoding to it.
-
 ## Amino in the Wild
 
 * Amino:binary spec in [Tendermint](
@@ -82,241 +69,6 @@ https://github.com/tendermint/tendermint/blob/develop/docs/specification/new-spe
 
 
 # Amino Spec
-
-## Supported types
-
-Amino supports 7 type families: These are Varint, 4-Byte, 8-Byte, Byte-Length
-(delimited), Struct, List, and Interface types.
-
-### Varint
-
-Varints in Amino are like Protobuf Varints.  They can be signed (uvarint) or
-unsigned (varint).  This type is used to encode `bool`, `byte`, `[u]int8`,
-`[u]int16` and optionally varint-encoded `[u]int32` and `[u]int64` numeric
-langauge types.
-
-The binary encoding for signed and unsigned Varints is such that the length is
-self-defined, but the encoding doesn't say whether the type is signed or
-unsigned.  As in Protobuf, signed varints are zig-zag encoded whereas unsigned
-varints are not. The schema is thus required in order to determine the correct
-numeric value.
-
-See https://developers.google.com/protocol-buffers/docs/encoding#varints for
-more information.
-
-### 4-Byte and 8-Byte
-
-These represent fixed-length 4-byte and 8-byte encodings for `[u]int32` and
-[u]int64` numeric langauge types.  They are big-endian encoded.  Like Varint
-and Uvarints, these types may be signed or unsigned, so the schema is required
-to determine the correct numeric value.
-
-### Byte-Length
-
-Byte-Length delimited fields are used to encode `[]byte` and `string` language
-types.
-
-The encoding schema for a Byte-Length types is as follows:
-
-```
-<uvarint(len(bytes))><bytes>
-e.g. <03><66 6f 6f> encodes the string "foo"
-```
-
-### Lists
-
-Lists can hold zero or many items of any single Amino type.
-
-The encoding schema for a List is as follows:
-
-```
-<typ3 of list items><uvarint(len(list))><encoding(first item)>...<encoding(last item)>
-e.g. <00><02><01><03> encodes a List of two Varints, 1 (or -1 if signed) and 3 (or -2).
-e.g. <06><01><00 02 01 03> encodes a List of Lists, with 1 item identical to the above List.
-```
-
-See example 3 below for more information on nillable Lists. The encoding schema
-for a nillable List is as follows:
-
-```
-<typ4 of list items w/ pointer-bit set><uvarint(len(list))>
-	<00, or 01 if first item is nil><encoding(first item)>...
-	<00, or 01 if last item is nil><encoding(last item)>
-```
-
-#### List example 1
-
-A List of Structs with `n` elements is encoded by the byte `0x03` followed by
-the uvarint encoding of `n`, followed by the binary encoding of each element.
-Each Struct element is encoded starting with the first field key, and is
-terminated with the Struct-terminator byte 0x04.
-
-```go
-type Item struct {
-	Number int
-}
-
-type List struct {
-	MyList []Item
-}
-
-list := List{
-	MyList: []Item{
-		Item{1},		// Item #0
-		Item{3},		// Item #1
-	}
-}
-
-bz, err := amino.MarshalBinary(list)
-if err != nil { ... }
-
-// dump bz:
-// BINARY      HEX   NOTE
-// b0000 1110  0x0E  Field number (1) and type (List) for `MyList`
-// b0000 0011  0x03  Type of element (Struct) of `MyList`
-// b0000 0010  0x02  Length of List (uvarint(2))
-//                   `Item` #0
-// b0000 1000  0x08  Field number (1) and type (Varint) for `MyList[0].Number`
-// b0000 0010  0x02  Field value (varint(1))
-// b0000 0100  0x04  StructTerm for `Item #0`
-//                   `Item` #1
-// b0000 1000  0x08  Field number (1) and type (Varint) for `MyList[1].Number`
-// b0000 0110  0x06  Field value (varint(3))
-// b0000 0100  0x04  StructTerm for `Item #1`
-```
-
-#### List example 2
-
-A List of `n` elements [where the elements are List-of-Structs] is encoded by
-the byte `0x06` followed by the uvarint encoding of `n`, followed by the binary
-encoding of each element each which start with the byte `0x03` followed by the
-uvarint encoding of `m` (the size of the first child List item).  Each Struct
-element is encoded starting with the first field key, as in the previous
-example.
-
-```go
-type Item struct {
-	Number int
-}
-
-type List []Item
-
-type ListOfLists struct {
-	MyLists []List
-}
-
-llist := ListOfLists{
-	MyLists: []List{
-		[]Item{			// List #0
-			Item{1},	// Item #0
-			Item{3},	// Item #1
-		},
-	}
-}
-
-bz, err := amino.MarshalBinary(llist)
-if err != nil { ... }
-
-// dump bz:
-// BINARY      HEX   NOTE
-// b0000 1110  0x0E  Field number (1) and type ([]List) for `MyLists`
-// b0000 0110  0x06  Type of element (List) of `MyLists`
-// b0000 0001  0x01  Length of List (uvarint(1))
-//                   `List` #0
-// b0000 0011  0x03  Type of element (Struct) of `MyLists[0]`
-// b0000 0010  0x02  Length of List (uvarint(2))
-//                   `Item` #0
-// b0000 1000  0x08  Field number (1) and type (Varint) for `MyLists[0][0].Number`
-// b0000 0010  0x02  Field value (varint(1))
-// b0000 0100  0x04  StructTerm for `Item #0`
-//                   `Item` #1
-// b0000 1000  0x08  Field number (1) and type (Varint) for `MyLists[0][1].Number`
-// b0000 0110  0x06  Field value (varint(3))
-// b0000 0100  0x04  StructTerm for `Item #1`
-```
-
-#### List example 3 (nilliable List)
-
-Unlike fields of a Struct where nil (or in the future, perhaps zero/empty)
-pointers are denoted by the absence of its encoding (both field key and value),
-elements of a List are encoded without an index or key.  They are just encoded
-one after the other, with no need to prefix each element with a key, index
-number nor typ3 byte.
-
-To declare that the List may contain nil elements (e.g. the List is
-"nillable"), the Lists's element typ4 byte should set the 4th least-significant
-bit (the "pointer bit") to 1.  If (and only if) the pointer bit is 1, each
-element is prefixed by a "nil byte" — a 0x00 byte to declare that a non-nil
-item follows, or a 0x01 byte to declare that the next item is nil.  Note that
-the byte values are flipped (typically 0 is used to denote nil).  This is to
-open the possibility of supporting sparse encoding of nil Lists in the future
-by encoding the number of nil items to skip as a uvarint.
-
-Nil Lists, Interfaces, (and in Go-Amino, nil pointers) are all encoded as nil
-in a nillable List.
-
-NOTE: A nil Interface in a nillable List is encoded with a single byte 0x01,
-while a nil Interface in a non-nillable List is encoded with two bytes 0x0000.
-
-```go
-type Item struct {
-	Number int
-}
-
-type List struct {
-	MyList []*Item
-}
-
-list := List{
-	MyList: []*Item{
-		Item{1},		// Item #0
-		nil,			// Item #1
-	}
-}
-
-bz, err := amino.MarshalBinary(list)
-if err != nil { ... }
-
-// dump bz:
-// BINARY      HEX   NOTE
-// b0000 1110  0x0E  Field number (1) and type (List) for `MyList`
-// b0000 1011  0x03  Type of element (nillable Struct) of `MyList`
-// b0000 0010  0x02  Length of List (uvarint(2))
-// b0000 0000  0x00  Byte to denote non-nil element
-// b0000 1000  0x08  Field number (1) and type (Varint) for `MyList[0].Number`
-// b0000 0010  0x02  Field value (varint(1))
-// b0000 0100  0x04  StructTerm for `Item #0`
-// b0000 0001  0x01  Byte to denote nil element
-```
-
-### Struct
-
-As in Protobuf, each Struct field is keyed by an unsigned Varint with the value
-`(field_number << 3) | field_typ3`, where `field_typ3` is the 3 bit typ3 of the
-field value.  The fields of a Struct are ordered by field number.
-
-All inner Structs end with a Struct-terminator byte 0x04.  Top-level Structs
-(e.g. structs as encoded by cdc.MarshalBinaryBare() in Go-Amino) does not end
-with a Struct-terminator, because top-level Structs can be implicitly
-terminated by the length of the input bytes.
-
-```
-<field_key><field_value> <field_key><field_value>... <Struct_term?>
-e.g. <08><14> <10><28> <20><3C> encodes a Struct with three Varint fields, of
-    values 20 (or 10 if signed) for field #1, 40 (or 20) for #2, and 60 (or 30) for
-    #3 respectively.
-e.g. <0E><06><01><<00><02><01><03>> encodes a Struct with a single field #1
-    which is a List type with one element which is itself a List with two Varints, 
-    1 (or -1 if signed) and 3 (or -2).
-e.g. <0A><<03><66 6F 6F>> <13><<08><01><04>> encodes a Struct with two fields,
-    a string or byteslice ("foo") for field #1, and an inner Struct with a single
-    Varint field with value 1 (or -1 if signed).  Notice the Struct-terminator
-    byte 0x04 which terminates the inner Struct, but not the root Struct.
-```
-
-Time is encoded as a Struct with two fields:
-1. Unix seconds since 1970 as an int64 (may be negative)
-2. Nanoseconds as an int32 (must be non-negative)
 
 ### Interface
 
@@ -334,11 +86,7 @@ detect any problems (such as conflicting prefix bytes -- more on that later).
 <field_key><field_value> <field_key><field_value>... <Struct_term?>
 ```
 
-A concrete type is typically a Struct type, but it doesn't need to be.  The
-last 3 bits of the written prefix bytes are the concrete type's typ3 bits, so a
-scanner can recursively traverse the fields and elements of the value.  A nil
-Interface value is encoded by 2 zero bytes (0x0000) in place of the 4 prefix
-bytes.  As in Protobuf, a nil Struct field value is not encoded at all.
+A concrete type is typically a Struct type, but it doesn't need to be.
 
 #### Registering types
 
@@ -366,12 +114,11 @@ decoded value will be a pointer as well.
 All registered concrete types are encoded with leading 4 bytes (called "prefix
 bytes"), even when it's not held in an Interface field/element.  In this way,
 Amino ensures that concrete types (almost) always have the same canonical
-representation.  The first byte of the prefix bytes must not be a zero byte, and
-the last 3 bits are reserved for the [`typ3` bits](#the-typ3-byte), so there
-are `2^(8x4-3)-2^(8x3-3) = 534,773,760` possible values.
+representation.  The first byte of the prefix bytes must not be a zero byte,
+so there are `2^(8x4)-2^(8x3) = 4,278,190,080` possible values.
 
 When there are 1024 concrete types registered that implement the same Interface,
-the probability of there being a conflict is ~ 0.1%.
+the probability of there being a conflict is ~ 0.01%.
 
 This is assuming that all registered concrete types have unique natural names
 (e.g.  prefixed by a unique entity name such as "com.tendermint/", and not
@@ -380,15 +127,15 @@ mine/grind to produce a particular sequence of prefix bytes, and avoid using
 dependencies that do so.
 
 ```
-The Birthday Paradox: 1024 random registered types, Amino prefix bytes
-https://instacalc.com/51339
+The Birthday Paradox: 1024 random registered types, Wire prefix bytes
+https://instacalc.com/51554
 
-possible = 534773760                                = 534,773,760
-registered = 1024                                   = 1,024
-pairs = ((registered)*(registered-1)) / 2           = 523,776
-no_collisions = ((possible-1) / possible)^pairs     = 0.99902104475
-any_collisions = 1 - no_collisions                  = 0.00097895525
-percent_any_collisions = any_collisions * 100       = 0.09789552533
+possible = 4278190080                               = 4,278,190,080 
+registered = 1024                                   = 1,024 
+pairs = ((registered)*(registered-1)) / 2           = 523,776 
+no_collisions = ((possible-1) / possible)^pairs     = 0.99987757816 
+any_collisions = 1 - no_collisions                  = 0.00012242184 
+percent_any_collisions = any_collisions * 100       = 0.01224218414 
 ```
 
 Since 4 bytes are not sufficient to ensure no conflicts, sometimes it is
@@ -437,16 +184,7 @@ The first 3 bytes are called the "disambiguation bytes" (in angle brackets).
 The next 4 bytes are called the "prefix bytes" (in square brackets).
 
 ```
-> <0xA8 0xFC 0x54> [0xBB 0x9C 9x83 9xDD] // Before stripping typ3 bits
-```
-
-We reserve the last 3 bits for the typ3 of the concrete type, so in
-this case the final prefix bytes become `(0xDD & 0xF8) | <typ3-byte>`.
-The type byte for a Struct is 0x03, so if the concrete type were a Struct,
-the final prefix byte would be `0xDB`.
-
-```
-> <0xA8 0xFC 0x54> [0xBB 0x9C 9x83 9xDB] // Final <Disamb Bytes> and [Prefix Bytes]
+> <0xA8 0xFC 0x54> [0xBB 0x9C 9x83 9xDD] // <Disamb Bytes> and [Prefix Bytes]
 ```
 
 ## Unsupported types
@@ -466,103 +204,3 @@ for maps for the Amino:JSON codec, but it shouldn't be relied on.  Ideally,
 each Amino library should decode maps as a List of key-value structs (in the
 case of langauges without generics, the library should maybe provide a custom
 Map implementation).  TODO specify the standard for key-value items.
-
-## Amino vs Protobuf3 in detail
-
-From the [Protocol Buffers encoding
-guide](https://developers.google.com/protocol-buffers/docs/encoding):
-
-> As you know, a protocol buffer message is a series of key-value pairs. The
-> binary version of a message just uses the field's number as the key – the
-> name and declared type for each field can only be determined on the decoding
-> end by referencing the message type's definition (i.e. the .proto file).
->
-> When a message is encoded, the keys and values are concatenated into a byte
-> stream. When the message is being decoded, the parser needs to be able to
-> skip fields that it doesn't recognize. This way, new fields can be added to a
-> message without breaking old programs that do not know about them. To this
-> end, the "key" for each pair in a wire-format message is actually two values
-> – the field number from your .proto file, plus a wire type that provides just
-> enough information to find the length of the following value.
->
-> The available wire types are as follows:
->
-> Type | Meaning | Used For
-> ---- | ------- | --------
-> 0    | Varint  | int32, int64, uint32, uint64, sint32, sint64, bool, enum
-> 1    | 64-bit  | fixed64, sfixed64, double
-> 2    | Length-prefixed | string, bytes, embedded messages, packed repeated fields
-> 3    | Start group | groups (deprecated)
-> 4    | End group | groups (deprecated)
-> 5    | 32-bit  | fixed32, sfixed32, float
->
-> Each key in the streamed message is a varint with the value (field_number <<
-> 3) | wire_type – in other words, the last three bits of the number store the
-> wire type.
-
-### The Typ3 Byte
-
-In Amino, the "type" is similarly encoded by 3 bits, called the "typ3". When it
-appears alone in a byte, it is called a "typ3 byte".
-
-In Amino, `varint` is the Protobuf equivalent of "signed varint" aka `sint32`,
-and `uvarint` is the equivalent of "varint" aka `int32`.
-
-Typ3 | Meaning          | Used For
----- | ---------------- | --------
-0    | Varint           | bool, byte, [u]int16, and varint-[u]int[64/32]
-1    | 8-Byte           | int64, uint64, float64(unsafe)
-2    | Byte-Length      | string, bytes, raw?
-3    | Struct           | struct (e.g. Protobuf message)
-4    | Struct Term      | end of struct
-5    | 4-Byte           | int32, uint32, float32(unsafe)
-6    | List             | array, slice; followed by element `<typ4-byte>`, then `<uvarint(num-items)>`
-7    | Interface        | registered concrete types; followed by `<prefix-bytes>` or `<disfix-bytes>`, the last byte which ends with the concrete type's `<typ3-byte>`.
-
-### Structs
-
-Struct fields are encoded in order, and a null/empty/zero field is represented
-by the absence of a field in the encoding, similar to Protobuf. Unlike Protobuf,
-in Amino, the total byte-size of a Amino encoded struct cannot in general be
-determined in a stream until each field's size has been determined by scanning
-all fields and elements recursively.
-
-As in Protobuf, each struct field is keyed by a uvarint with the value
-`(field_number << 3) | type`, where `type` is 3 bits long.
-
-When the typ3 bits are represented as a single byte (using the least
-significant bits of the byte), we call it the "typ3 byte".  For example, the
-typ3 byte for a List is `0x06`.
-
-Inner structs that are embedded in outer structs are encoded by the field typ3
-"Struct" (e.g. `0x03`).  (In Protobuf3, embedded messages are encoded as
-"Byte-Length (prefixed)".  In Amino, the "Byte-Length" typ3 is only used for
-byteslices and bytearrays.)
-
-### Lists
-
-Unlike Protobuf, Amino deprecates "repeated fields" in favor of Lists. A List
-is encoded by first writing the typ4 byte of the element type, followed by the
-uvarint encoding of the length of the List, followed by the encoding of each
-element.
-
-In Amino, when encoding elements of a List (Go slice or array), the typ3
-byte isn't enough.  Specifically, when the element type of the List is a
-pointer type, the element value may be nil.  We encode the element type of this
-kind of List with a typ4 byte, which is like a typ3 byte, but uses the 4th
-least significant bit to encode the "pointer bit".  In other words, the element
-typ4 byte follows the List typ3 bits--where the List typ3 bits appear as (1)
-the last 3 bits of a struct's field key, (2) the last 3 bits of an Interface's
-prefix bytes, or (3) the typ4 byte of a parent List's element type declaration.
-
-### Interfaces and concrete types
-
-Amino drops support of `oneof` and instead supports Interfaces. See the Amino
-Interface spec in this README for more information on how interfaces work.
-
-
-# Amino in other langauges
-
-[Open an Issue on GitHub](https://github.com/tendermint/go-amino/issues), as we
-will pay out bounties for implementations in other languages.  In Golang, we are
-are primarily interested in codec generators.

--- a/amino.go
+++ b/amino.go
@@ -189,13 +189,13 @@ func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = cdc.encodeReflectBinary(buf, info, rv, true, FieldOptions{})
+	err = cdc.encodeReflectBinary(buf, info, rv, FieldOptions{}, true)
 	if err != nil {
 		return nil, err
 	}
 	bz = buf.Bytes()
 
-	// If registered concrete, prepend prefix+typ3 bytes.
+	// If registered concrete, prepend prefix bytes.
 	if info.Registered {
 		typ := typeToTyp3(rt, FieldOptions{})
 		pb := info.Prefix.Bytes()
@@ -317,7 +317,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 	if err != nil {
 		return err
 	}
-	// If registered concrete, consume and verify prefix+typ3 bytes.
+	// If registered concrete, consume and verify prefix bytes.
 	if info.Registered {
 		typ := typeToTyp3(rt, FieldOptions{})
 		pb := info.Prefix.Bytes()
@@ -329,7 +329,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 		bz = bz[4:]
 	}
 	// Decode contents into rv.
-	n, err := cdc.decodeReflectBinary(bz, info, rv, true, FieldOptions{})
+	n, err := cdc.decodeReflectBinary(bz, info, rv, FieldOptions{}, true)
 	if err != nil {
 		return err
 	}

--- a/amino.go
+++ b/amino.go
@@ -71,10 +71,9 @@ func MarshalJSONIndent(o interface{}, prefix, indent string) ([]byte, error) {
 }
 
 //----------------------------------------
-// Typ3 and Typ4
+// Typ3
 
 type Typ3 uint8
-type Typ4 uint8 // Typ3 | 0x08 (pointer bit)
 
 const (
 	// Typ3 types
@@ -86,9 +85,6 @@ const (
 	Typ3_4Byte      = Typ3(5)
 	Typ3_List       = Typ3(6)
 	Typ3_Interface  = Typ3(7)
-
-	// Typ4 bit
-	Typ4_Pointer = Typ4(0x08)
 )
 
 func (typ Typ3) String() string {
@@ -111,19 +107,6 @@ func (typ Typ3) String() string {
 		return "Interface"
 	default:
 		return fmt.Sprintf("<Invalid Typ3 %X>", byte(typ))
-	}
-}
-
-func (typ Typ4) Typ3() Typ3      { return Typ3(typ & 0x07) }
-func (typ Typ4) IsPointer() bool { return (typ & 0x08) > 0 }
-func (typ Typ4) String() string {
-	if typ&0xF0 != 0 {
-		return fmt.Sprintf("<Invalid Typ4 %X>", byte(typ))
-	}
-	if typ&0x08 != 0 {
-		return "*" + Typ3(typ&0x07).String()
-	} else {
-		return Typ3(typ).String()
 	}
 }
 
@@ -215,7 +198,7 @@ func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 	// If registered concrete, prepend prefix+typ3 bytes.
 	if info.Registered {
 		typ := typeToTyp3(rt, FieldOptions{})
-		pb := info.Prefix.WithTyp3(typ).Bytes()
+		pb := info.Prefix.Bytes()
 		bz = append(pb, bz...)
 	}
 
@@ -337,7 +320,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 	// If registered concrete, consume and verify prefix+typ3 bytes.
 	if info.Registered {
 		typ := typeToTyp3(rt, FieldOptions{})
-		pb := info.Prefix.WithTyp3(typ).Bytes()
+		pb := info.Prefix.Bytes()
 		if len(bz) <= 4 {
 			return fmt.Errorf("UnmarshalBinaryBare expected to read prefix bytes %X (since it is registered concrete) but got %X", pb, bz)
 		} else if !bytes.Equal(bz[:4], pb) {

--- a/amino.go
+++ b/amino.go
@@ -197,7 +197,6 @@ func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 
 	// If registered concrete, prepend prefix bytes.
 	if info.Registered {
-		typ := typeToTyp3(rt, FieldOptions{})
 		pb := info.Prefix.Bytes()
 		bz = append(pb, bz...)
 	}
@@ -319,7 +318,6 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 	}
 	// If registered concrete, consume and verify prefix bytes.
 	if info.Registered {
-		typ := typeToTyp3(rt, FieldOptions{})
 		pb := info.Prefix.Bytes()
 		if len(bz) <= 4 {
 			return fmt.Errorf("UnmarshalBinaryBare expected to read prefix bytes %X (since it is registered concrete) but got %X", pb, bz)
@@ -331,7 +329,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 	// Decode contents into rv.
 	n, err := cdc.decodeReflectBinary(bz, info, rv, FieldOptions{}, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("Unmarshal failed after %v bytes: %v", n, err)
 	}
 	if n != len(bz) {
 		return fmt.Errorf("Unmarshal didn't read all bytes. Expected to read %v, only read %v", len(bz), n)

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -280,7 +280,6 @@ func (cdc *Codec) encodeReflectBinaryList(w io.Writer, info *TypeInfo, rv reflec
 			// Get dereferenced element value (or zero).
 			var erv, _, _ = derefPointersZero(rv.Index(i))
 			// Write the element value.
-			// It may be a nil interface, but not a nil pointer.
 			err = cdc.encodeReflectBinary(buf, einfo, erv, fopts)
 			if err != nil {
 				return
@@ -307,15 +306,10 @@ func (cdc *Codec) encodeReflectBinaryList(w io.Writer, info *TypeInfo, rv reflec
 				}
 			} else {
 				// Write the element value to a buffer.
-				// It may be a nil interface, but not a nil pointer.
-				buf := bytes.NewBuffer()
-				err = cdc.encodeReflectBinary(buf, einfo, erv, fopts)
+				err = cdc.encodeReflectBinary(buf, einfo, erv, fopts, false)
 				if err != nil {
 					return
 				}
-				// Write byte-length prefixed byteslice.
-				err = EncodeByteSlice(w, buf.Bytes())
-				return
 			}
 		}
 	}

--- a/cmd/aminoscan.go
+++ b/cmd/aminoscan.go
@@ -225,12 +225,13 @@ func scanList(bz []byte, indent string) (s string, n int, err error) {
 	return
 }
 
+/*
 func scanInterface(bz []byte, indent string) (s string, n int, err error) {
 	db, hasDb, pb, typ, _, isNil, _n, err := amino.DecodeDisambPrefixBytes(bz)
 	if slide(&bz, &n, _n) && err != nil {
 		return
 	}
-	pb3 := pb.WithTyp3(typ)
+	pb3 := pb
 	if isNil {
 		s = cmn.Magenta("0000")
 	} else if hasDb {
@@ -253,6 +254,7 @@ func scanInterface(bz []byte, indent string) (s string, n int, err error) {
 	}
 	return
 }
+*/
 
 //----------------------------------------
 // Misc.

--- a/codec.go
+++ b/codec.go
@@ -111,8 +111,8 @@ type FieldInfo struct {
 	Type         reflect.Type  // Struct field type
 	Index        int           // Struct field index
 	ZeroValue    reflect.Value // Could be nil pointer unlike TypeInfo.ZeroValue.
+	UnpackedList bool          // True iff this field should be encoded as an unpacked list.
 	FieldOptions               // Encoding options
-	BinTyp3      Typ3          // (Binary) Typ3 byte
 }
 
 type FieldOptions struct {
@@ -150,7 +150,7 @@ func NewCodec() *Codec {
 // encoded/decoded by go-amino.
 // Usage:
 // `amino.RegisterInterface((*MyInterface1)(nil), nil)`
-func (cdc *Codec) RegisterInterface(ptr interface{}, opts *InterfaceOptions) {
+func (cdc *Codec) RegisterInterface(ptr interface{}, iopts *InterfaceOptions) {
 	cdc.assertNotSealed()
 
 	// Get reflect.Type from ptr.
@@ -160,7 +160,7 @@ func (cdc *Codec) RegisterInterface(ptr interface{}, opts *InterfaceOptions) {
 	}
 
 	// Construct InterfaceInfo
-	var info = cdc.newTypeInfoFromInterfaceType(rt, opts)
+	var info = cdc.newTypeInfoFromInterfaceType(rt, iopts)
 
 	// Finally, check conflicts and register.
 	func() {
@@ -205,7 +205,7 @@ func (cdc *Codec) RegisterInterface(ptr interface{}, opts *InterfaceOptions) {
 // interface fields/elements to be encoded/decoded by go-amino.
 // Usage:
 // `amino.RegisterConcrete(MyStruct1{}, "com.tendermint/MyStruct1", nil)`
-func (cdc *Codec) RegisterConcrete(o interface{}, name string, opts *ConcreteOptions) {
+func (cdc *Codec) RegisterConcrete(o interface{}, name string, copts *ConcreteOptions) {
 	cdc.assertNotSealed()
 
 	var pointerPreferred bool
@@ -229,7 +229,7 @@ func (cdc *Codec) RegisterConcrete(o interface{}, name string, opts *ConcreteOpt
 	}
 
 	// Construct ConcreteInfo.
-	var info = cdc.newTypeInfoFromRegisteredConcreteType(rt, pointerPreferred, name, opts)
+	var info = cdc.newTypeInfoFromRegisteredConcreteType(rt, pointerPreferred, name, copts)
 
 	// Finally, check conflicts and register.
 	func() {
@@ -362,23 +362,37 @@ func (cdc *Codec) parseStructInfo(rt reflect.Type) (sinfo StructInfo) {
 	for i := 0; i < rt.NumField(); i++ {
 		var field = rt.Field(i)
 		var ftype = field.Type
+		var unpackedList = false
 		if !isExported(field) {
 			continue // field is unexported
 		}
-		skip, opts := cdc.parseFieldOptions(field)
+		skip, fopts := cdc.parseFieldOptions(field)
 		if skip {
 			continue // e.g. json:"-"
 		}
+		if ftype.Kind() == reflect.Array || ftype.Kind() == reflect.Slice {
+			if ftype.Elem().Kind() == reflect.Uint8 {
+				// These get handled by our optimized methods,
+				// encodeReflectBinaryByte[Slice/Array].
+				unpackedList = false
+			} else {
+				einfo := cdc.getTypeInfo_wlock(ftype.Elem())
+				typ3 := typeToTyp3(einfo.Type, fopts)
+				if typ3 == Typ3_ByteLength {
+					unpackedList = true
+				}
+			}
+		}
 		// NOTE: This is going to change a bit.
 		// NOTE: BinFieldNum starts with 1.
-		opts.BinFieldNum = uint32(len(infos) + 1)
+		fopts.BinFieldNum = uint32(len(infos) + 1)
 		fieldInfo := FieldInfo{
 			Name:         field.Name, // Mostly for debugging.
 			Index:        i,
 			Type:         ftype,
 			ZeroValue:    reflect.Zero(ftype),
-			FieldOptions: opts,
-			BinTyp3:      typeToTyp4(ftype, opts).Typ3(),
+			UnpackedList: unpackedList,
+			FieldOptions: fopts,
 		}
 		checkUnsafe(fieldInfo)
 		infos = append(infos, fieldInfo)
@@ -387,7 +401,7 @@ func (cdc *Codec) parseStructInfo(rt reflect.Type) (sinfo StructInfo) {
 	return
 }
 
-func (cdc *Codec) parseFieldOptions(field reflect.StructField) (skip bool, opts FieldOptions) {
+func (cdc *Codec) parseFieldOptions(field reflect.StructField) (skip bool, fopts FieldOptions) {
 	binTag := field.Tag.Get("binary")
 	aminoTag := field.Tag.Get("amino")
 	jsonTag := field.Tag.Get("json")
@@ -402,26 +416,26 @@ func (cdc *Codec) parseFieldOptions(field reflect.StructField) (skip bool, opts 
 	// Get JSON field name.
 	jsonTagParts := strings.Split(jsonTag, ",")
 	if jsonTagParts[0] == "" {
-		opts.JSONName = field.Name
+		fopts.JSONName = field.Name
 	} else {
-		opts.JSONName = jsonTagParts[0]
+		fopts.JSONName = jsonTagParts[0]
 	}
 
 	// Get JSON omitempty.
 	if len(jsonTagParts) > 1 {
 		if jsonTagParts[1] == "omitempty" {
-			opts.JSONOmitEmpty = true
+			fopts.JSONOmitEmpty = true
 		}
 	}
 
 	// Parse binary tags.
 	if binTag == "varint" { // TODO: extend
-		opts.BinVarint = true
+		fopts.BinVarint = true
 	}
 
 	// Parse amino tags.
 	if aminoTag == "unsafe" {
-		opts.Unsafe = true
+		fopts.Unsafe = true
 	}
 
 	return
@@ -455,7 +469,7 @@ func (cdc *Codec) newTypeInfoUnregistered(rt reflect.Type) *TypeInfo {
 	return info
 }
 
-func (cdc *Codec) newTypeInfoFromInterfaceType(rt reflect.Type, opts *InterfaceOptions) *TypeInfo {
+func (cdc *Codec) newTypeInfoFromInterfaceType(rt reflect.Type, iopts *InterfaceOptions) *TypeInfo {
 	if rt.Kind() != reflect.Interface {
 		panic(fmt.Sprintf("expected interface type, got %v", rt))
 	}
@@ -466,11 +480,11 @@ func (cdc *Codec) newTypeInfoFromInterfaceType(rt reflect.Type, opts *InterfaceO
 	info.ZeroValue = reflect.Zero(rt)
 	info.ZeroProto = reflect.Zero(rt).Interface()
 	info.InterfaceInfo.Implementers = make(map[PrefixBytes][]*TypeInfo)
-	if opts != nil {
-		info.InterfaceInfo.InterfaceOptions = *opts
-		info.InterfaceInfo.Priority = make([]DisfixBytes, len(opts.Priority))
+	if iopts != nil {
+		info.InterfaceInfo.InterfaceOptions = *iopts
+		info.InterfaceInfo.Priority = make([]DisfixBytes, len(iopts.Priority))
 		// Construct Priority []DisfixBytes
-		for i, name := range opts.Priority {
+		for i, name := range iopts.Priority {
 			disamb, prefix := nameToDisfix(name)
 			disfix := toDisfix(disamb, prefix)
 			info.InterfaceInfo.Priority[i] = disfix
@@ -479,7 +493,7 @@ func (cdc *Codec) newTypeInfoFromInterfaceType(rt reflect.Type, opts *InterfaceO
 	return info
 }
 
-func (cdc *Codec) newTypeInfoFromRegisteredConcreteType(rt reflect.Type, pointerPreferred bool, name string, opts *ConcreteOptions) *TypeInfo {
+func (cdc *Codec) newTypeInfoFromRegisteredConcreteType(rt reflect.Type, pointerPreferred bool, name string, copts *ConcreteOptions) *TypeInfo {
 	if rt.Kind() == reflect.Interface ||
 		rt.Kind() == reflect.Ptr {
 		panic(fmt.Sprintf("expected non-interface non-pointer concrete type, got %v", rt))
@@ -491,8 +505,8 @@ func (cdc *Codec) newTypeInfoFromRegisteredConcreteType(rt reflect.Type, pointer
 	info.ConcreteInfo.Name = name
 	info.ConcreteInfo.Disamb = nameToDisamb(name)
 	info.ConcreteInfo.Prefix = nameToPrefix(name)
-	if opts != nil {
-		info.ConcreteOptions = *opts
+	if copts != nil {
+		info.ConcreteOptions = *copts
 	}
 	return info
 }

--- a/codec.go
+++ b/codec.go
@@ -34,14 +34,8 @@ func NewPrefixBytes(prefixBytes []byte) PrefixBytes {
 	return pb
 }
 
-func (pb PrefixBytes) Bytes() []byte                 { return pb[:] }
-func (pb PrefixBytes) EqualBytes(bz []byte) bool     { return bytes.Equal(pb[:], bz) }
-func (pb PrefixBytes) WithTyp3(typ Typ3) PrefixBytes { pb[3] |= byte(typ); return pb }
-func (pb PrefixBytes) SplitTyp3() (PrefixBytes, Typ3) {
-	typ := Typ3(pb[3] & 0x07)
-	pb[3] &= 0xF8
-	return pb, typ
-}
+func (pb PrefixBytes) Bytes() []byte             { return pb[:] }
+func (pb PrefixBytes) EqualBytes(bz []byte) bool { return bytes.Equal(pb[:], bz) }
 func (db DisambBytes) Bytes() []byte             { return db[:] }
 func (db DisambBytes) EqualBytes(bz []byte) bool { return bytes.Equal(db[:], bz) }
 func (df DisfixBytes) Bytes() []byte             { return df[:] }
@@ -657,8 +651,6 @@ func nameToDisfix(name string) (db DisambBytes, pb PrefixBytes) {
 		bz = bz[1:]
 	}
 	copy(pb[:], bz[0:4])
-	// Drop the last 3 bits to make room for the Typ3.
-	pb[3] &= 0xF8
 	return
 }
 

--- a/codec.go
+++ b/codec.go
@@ -370,8 +370,11 @@ func (cdc *Codec) parseStructInfo(rt reflect.Type) (sinfo StructInfo) {
 				// encodeReflectBinaryByte[Slice/Array].
 				unpackedList = false
 			} else {
-				einfo := cdc.getTypeInfo_wlock(ftype.Elem())
-				typ3 := typeToTyp3(einfo.Type, fopts)
+				etype := ftype.Elem()
+				for etype.Kind() == reflect.Ptr {
+					etype = etype.Elem()
+				}
+				typ3 := typeToTyp3(etype, fopts)
 				if typ3 == Typ3_ByteLength {
 					unpackedList = true
 				}

--- a/decoder.go
+++ b/decoder.go
@@ -187,7 +187,7 @@ func DecodeFloat64(bz []byte) (f float64, n int, err error) {
 // range [0, 999999999], or if seconds is too large, the behavior is
 // undefined.
 // TODO return error if behavior is undefined.
-func DecodeTime(bz []byte, isRoot bool) (t time.Time, n int, err error) {
+func DecodeTime(bz []byte) (t time.Time, n int, err error) {
 
 	// TODO: This is a temporary measure until we support MarshalAmino/UnmarshalAmino.
 	// Basically, MarshalAmino on time should return a struct.
@@ -240,18 +240,6 @@ func DecodeTime(bz []byte, isRoot bool) (t time.Time, n int, err error) {
 	if nsec < 0 || 999999999 < nsec {
 		err = fmt.Errorf("invalid time, nanoseconds out of bounds %v", nsec)
 		return
-	}
-	// If !isRoot, expect "StructTerm" Typ3 byte.
-	if !isRoot {
-		var typ, _n = Typ3(0x00), int(0)
-		typ, _n, err = decodeTyp3(bz)
-		if slide(&bz, &n, _n) && err != nil {
-			return
-		}
-		if typ != Typ3_StructTerm {
-			err = errors.New(fmt.Sprintf("expected StructTerm Typ3 byte for non-root time, got %v", typ))
-			return
-		}
 	}
 	// Construct time.
 	t = time.Unix(sec, int64(nsec))

--- a/encoder.go
+++ b/encoder.go
@@ -114,7 +114,7 @@ func EncodeFloat64(w io.Writer, f float64) (err error) {
 // Int64.
 // Milliseconds are used to ease compatibility with Javascript,
 // which does not support finer resolution.
-func EncodeTime(w io.Writer, t time.Time, isRoot bool) (err error) {
+func EncodeTime(w io.Writer, t time.Time) (err error) {
 	var s = t.Unix()
 	var ns = int32(t.Nanosecond()) // this int64 -> int32 is safe.
 
@@ -136,10 +136,6 @@ func EncodeTime(w io.Writer, t time.Time, isRoot bool) (err error) {
 	err = EncodeInt32(w, ns)
 	if err != nil {
 		return
-	}
-
-	if !isRoot {
-		err = EncodeByte(w, byte(0x04)) // StructTerm
 	}
 
 	return

--- a/example_test.go
+++ b/example_test.go
@@ -65,7 +65,7 @@ func Example() {
 	fmt.Printf("Decoded successfully: %v\n", *bm == *bm2)
 
 	// Output:
-	// Encoded: 0C740613630A0341424310C801 (err: <nil>)
+	// Encoded: 0C740613650A0341424310C801 (err: <nil>)
 	// Decoded: &{ABC 100} (err: <nil>)
 	// Decoded successfully: true
 }

--- a/json_test.go
+++ b/json_test.go
@@ -24,7 +24,6 @@ func registerTransports(cdc *amino.Codec) {
 }
 
 func TestMarshalJSON(t *testing.T) {
-	t.Parallel()
 	var cdc = amino.NewCodec()
 	registerTransports(cdc)
 	cases := []struct {
@@ -238,7 +237,6 @@ func TestUnmarshalFunc(t *testing.T) {
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	t.Parallel()
 	var cdc = amino.NewCodec()
 	registerTransports(cdc)
 	cases := []struct {
@@ -567,7 +565,6 @@ func TestMarshalJSONMap(t *testing.T) {
 }
 
 func TestMarshalJSONIndent(t *testing.T) {
-	t.Parallel()
 	var cdc = amino.NewCodec()
 	registerTransports(cdc)
 	obj := Car("Tesla")

--- a/reflect.go
+++ b/reflect.go
@@ -51,7 +51,9 @@ func slide(bz *[]byte, n *int, _n int) bool {
 		panic(fmt.Sprintf("impossible slide: len:%v _n:%v", len(*bz), _n))
 	}
 	*bz = (*bz)[_n:]
-	*n += _n
+	if n != nil {
+		*n += _n
+	}
 	return true
 }
 
@@ -125,43 +127,17 @@ func constructConcreteType(cinfo *TypeInfo) (crv, irvSet reflect.Value) {
 	return
 }
 
-// Like typeToTyp4 but include a pointer bit.
-func typeToTyp4(rt reflect.Type, opts FieldOptions) (typ Typ4) {
-
-	// Dereference pointer type.
-	var pointer = false
-	for rt.Kind() == reflect.Ptr {
-		pointer = true
-		rt = rt.Elem()
-	}
-
-	// Call actual logic.
-	typ = Typ4(typeToTyp3(rt, opts))
-
-	// Set pointer bit to 1 if pointer.
-	if pointer {
-		typ |= Typ4_Pointer
-	}
-	return
-}
-
 // CONTRACT: rt.Kind() != reflect.Ptr
 func typeToTyp3(rt reflect.Type, opts FieldOptions) Typ3 {
 	switch rt.Kind() {
 	case reflect.Interface:
 		return Typ3_Interface
 	case reflect.Array, reflect.Slice:
-		ert := rt.Elem()
-		switch ert.Kind() {
-		case reflect.Uint8:
-			return Typ3_ByteLength
-		default:
-			return Typ3_List
-		}
+		return Typ3_ByteLength
 	case reflect.String:
 		return Typ3_ByteLength
 	case reflect.Struct, reflect.Map:
-		return Typ3_Struct
+		return Typ3_ByteLength
 	case reflect.Int64, reflect.Uint64:
 		if opts.BinVarint {
 			return Typ3_Varint

--- a/reflect.go
+++ b/reflect.go
@@ -131,7 +131,7 @@ func constructConcreteType(cinfo *TypeInfo) (crv, irvSet reflect.Value) {
 func typeToTyp3(rt reflect.Type, opts FieldOptions) Typ3 {
 	switch rt.Kind() {
 	case reflect.Interface:
-		return Typ3_Interface
+		return Typ3_ByteLength
 	case reflect.Array, reflect.Slice:
 		return Typ3_ByteLength
 	case reflect.String:

--- a/reflect.go
+++ b/reflect.go
@@ -74,6 +74,28 @@ func derefPointers(rv reflect.Value) (drv reflect.Value, isPtr bool, isNilPtr bo
 	return
 }
 
+// Dereference pointer recursively or return zero value.
+// drv: the final non-pointer value (which is never invalid).
+// isPtr: whether rv.Kind() == reflect.Ptr.
+// isNilPtr: whether a nil pointer at any level.
+func derefPointersZero(rv reflect.Value) (drv reflect.Value, isPtr bool, isNilPtr bool) {
+	for rv.Kind() == reflect.Ptr {
+		isPtr = true
+		if rv.IsNil() {
+			isNilPtr = true
+			rt := rv.Type().Elem()
+			for rt.Kind() == reflect.Ptr {
+				rt = rt.Elem()
+			}
+			drv = reflect.New(rt).Elem()
+			return
+		}
+		rv = rv.Elem()
+	}
+	drv = rv
+	return
+}
+
 // Returns isDefaultValue=true iff is ultimately nil or empty after (recursive)
 // dereferencing. If isDefaultValue=false, erv is set to the non-nil non-empty
 // non-default dereferenced value.

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -160,7 +160,7 @@ func TestCodecBinaryRegister2(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
-	assert.Equal(t, []byte{0x0f, 0xe3, 0xda, 0xb8, 0x33, 0x04}, bz,
+	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
 }
 
@@ -171,7 +171,7 @@ func TestCodecBinaryRegister3(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
-	assert.Equal(t, []byte{0x0f, 0xe3, 0xda, 0xb8, 0x33, 0x04}, bz,
+	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
 }
 
@@ -184,7 +184,7 @@ func TestCodecBinaryRegister4(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
-	assert.Equal(t, []byte{0x0f, 0x00, 0x12, 0xb5, 0x86, 0xe3, 0xda, 0xb8, 0x33, 0x04}, bz,
+	assert.Equal(t, []byte{0xa, 0x8, 0x0, 0x12, 0xb5, 0x86, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
 }
 
@@ -217,14 +217,14 @@ func TestCodecBinaryRegister7(t *testing.T) {
 	{ // test tests.Concrete1, no conflict.
 		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 		assert.Nil(t, err, "correctly registered")
-		assert.Equal(t, []byte{0x0f, 0xe3, 0xda, 0xb8, 0x33, 0x04}, bz,
+		assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 			"disfix bytes did not match")
 	}
 
 	{ // test tests.Concrete2, no conflict
 		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete2{}})
 		assert.Nil(t, err, "correctly registered")
-		assert.Equal(t, []byte{0x0f, 0x6a, 0x9, 0xca, 0x3, 0x04}, bz,
+		assert.Equal(t, []byte{0xa, 0x4, 0x6a, 0x9, 0xca, 0x1}, bz,
 			"disfix bytes did not match")
 	}
 }
@@ -244,7 +244,7 @@ func TestCodecBinaryRegister8(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x2, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
+	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -290,7 +290,7 @@ func TestCodecBinaryRegister9(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x02, 0x04, 0x30, 0x31, 0x32, 0x33}, bz,
+	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -310,7 +310,7 @@ func TestCodecBinaryRegister10(t *testing.T) {
 
 	bz, err := cdc.MarshalBinaryBare(c3a)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x02, 0x04, 0x30, 0x31, 0x32, 0x33}, bz,
+	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var c3b tests.Concrete3


### PR DESCRIPTION
This PR makes Amino:binary compatible with Proto3 (but not Proto2).  It doesn't implement all of the features of Proto3, but everything should be parseable in Proto3.

Notable differences are, support of Interfaces as byte-length prefixed blobs.  Support for nested arrays is also interesting.

This makes the encoder slower, but the purpose is to start with Proto3 compatibility and work toward Amin2.

Many thanks to @ebuchman and @mdyring for exploring this.