### PR TITLE
Don't encode zero values in time

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -119,23 +119,27 @@ func EncodeTime(w io.Writer, t time.Time) (err error) {
 	var ns = int32(t.Nanosecond()) // this int64 -> int32 is safe.
 
 	// TODO: We are hand-encoding a struct until MarshalAmino/UnmarshalAmino is supported.
-
-	err = encodeFieldNumberAndTyp3(w, 1, Typ3_8Byte)
-	if err != nil {
-		return
+	// skip if default/zero value:
+	if s != 0 {
+		err = encodeFieldNumberAndTyp3(w, 1, Typ3_8Byte)
+		if err != nil {
+			return
+		}
+		err = EncodeInt64(w, s)
+		if err != nil {
+			return
+		}
 	}
-	err = EncodeInt64(w, s)
-	if err != nil {
-		return
-	}
-
-	err = encodeFieldNumberAndTyp3(w, 2, Typ3_4Byte)
-	if err != nil {
-		return
-	}
-	err = EncodeInt32(w, ns)
-	if err != nil {
-		return
+	// skip if default/zero value:
+	if ns != 0 {
+		err = encodeFieldNumberAndTyp3(w, 2, Typ3_4Byte)
+		if err != nil {
+			return
+		}
+		err = EncodeInt32(w, ns)
+		if err != nil {
+			return
+		}
 	}
 
 	return


### PR DESCRIPTION
Skip over default values (zeroes) in `EncodeTime` (as proto3 does).