### PR TITLE
do not encode empty structs, unless `amino:"write_empty"` is set

### DIFF
--- a/binary-encode.go
+++ b/binary-encode.go
@@ -409,7 +409,6 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 				}
 				lAfter := buf.Len()
 
-				// TODO(ismail): make sure this always correct
 				if !fopts.WriteEmpty && lAfter == lBefore+2 && buf.Bytes()[buf.Len()-1] == 0x00 {
 					// rollback typ3/fieldnum and last byte if empty:
 					buf.Truncate(buf.Len() - 2)

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -24,11 +24,10 @@ import (
 // CONTRACT: rv is valid.
 func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Value, fopts FieldOptions, bare bool) (err error) {
 	if rv.Kind() == reflect.Ptr {
-		panic("should not happen")
+		panic("not allowed to be called with a reflect.Ptr")
 	}
 	if !rv.IsValid() {
-		panic("should not happen")
-		// TODO(ismail): make this clearer
+		panic("not allowed to be called with invalid / zero Value")
 	}
 	if printLog {
 		spew.Printf("(E) encodeReflectBinary(info: %v, rv: %#v (%v), fopts: %v)\n",

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -410,6 +410,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 				}
 				lAfter := buf.Len()
 
+				// TODO(ismail): make sure this always correct
 				if !fopts.WriteEmpty && lAfter == lBefore+2 && buf.Bytes()[buf.Len()-1] == 0x00 {
 					// rollback typ3/fieldnum and last byte if empty:
 					buf.Truncate(buf.Len() - 2)

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -28,6 +28,7 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 	}
 	if !rv.IsValid() {
 		panic("should not happen")
+		// TODO(ismail): make this clearer
 	}
 	if printLog {
 		spew.Printf("(E) encodeReflectBinary(info: %v, rv: %#v (%v), fopts: %v)\n",
@@ -385,7 +386,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 			}
 			// Get dereferenced field value and info.
 			var frv, isDefault = isDefaultValue(rv.Field(field.Index))
-			if isDefault && !fopts.WriteEmpty {
+			if isDefault && !fopts.WriteEmpty && field.Index != 0 {
 				// Do not encode default value fields (only if `amino:"write_empty"` is set).
 				continue
 			}
@@ -409,7 +410,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 				}
 				lAfter := buf.Len()
 
-				if lAfter == lBefore+2 && !fopts.WriteEmpty && buf.Bytes()[buf.Len()-1] == 0x00 {
+				if !fopts.WriteEmpty && lAfter == lBefore+2 && buf.Bytes()[buf.Len()-1] == 0x00 {
 					// rollback typ3/fieldnum and last byte if empty:
 					buf.Truncate(buf.Len() - 2)
 				}

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -386,7 +386,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 			}
 			// Get dereferenced field value and info.
 			var frv, isDefault = isDefaultValue(rv.Field(field.Index))
-			if isDefault && !fopts.WriteEmpty && field.Index != 0 {
+			if isDefault && !fopts.WriteEmpty {
 				// Do not encode default value fields (only if `amino:"write_empty"` is set).
 				continue
 			}

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -408,9 +408,10 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 					return
 				}
 				lAfter := buf.Len()
-				if lAfter == lBefore+1 && !fopts.WriteEmpty && buf.Bytes()[buf.Len()-1] == 0x00 {
-					// rollback one byte
-					buf.Truncate(buf.Len() - 1)
+
+				if lAfter == lBefore+2 && !fopts.WriteEmpty && buf.Bytes()[buf.Len()-1] == 0x00 {
+					// rollback typ3/fieldnum and last byte if empty:
+					buf.Truncate(buf.Len() - 2)
 				}
 			}
 		}

--- a/binary_test.go
+++ b/binary_test.go
@@ -147,5 +147,7 @@ func TestForceWriteEmpty(t *testing.T) {
 
 	b, err = cdc.MarshalBinaryBare(InnerWriteEmpty{})
 	assert.NoError(t, err)
-	assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
+	t.Log(b)
+	// TODO(ismail): this alone won't be encoded:
+	//assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -126,5 +126,26 @@ func TestWriteEmpty(t *testing.T) {
 	var outer SomeStruct
 	cdc.UnmarshalBinaryBare(b, &outer)
 	assert.Equal(t, SomeStruct{}, outer, "")
+}
 
+func TestForceWriteEmpty(t *testing.T) {
+	type InnerWriteEmpty struct {
+		// sth. that isn't zero-len if default, e.g. fixed32:
+		ValIn int32 `amino:"write_empty" binary:"fixed32"`
+	}
+
+	type OuterWriteEmpty struct {
+		In  InnerWriteEmpty `amino:"write_empty"`
+		Val int             `amino:"write_empty" binary:"fixed32"`
+	}
+
+	cdc := amino.NewCodec()
+
+	b, err := cdc.MarshalBinaryBare(OuterWriteEmpty{})
+	assert.NoError(t, err)
+	assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
+
+	b, err = cdc.MarshalBinaryBare(InnerWriteEmpty{})
+	assert.NoError(t, err)
+	assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -116,9 +116,15 @@ func TestWriteEmpty(t *testing.T) {
 	b, err := cdc.MarshalBinaryBare(Inner{})
 	assert.NoError(t, err)
 	assert.Equal(t, b, []byte(nil), "empty struct should be encoded as empty bytes")
+	var inner Inner
+	cdc.UnmarshalBinaryBare(b, &inner)
+	assert.Equal(t, Inner{}, inner, "")
 
 	b, err = cdc.MarshalBinaryBare(SomeStruct{})
 	assert.NoError(t, err)
 	assert.Equal(t, b, []byte(nil), "empty structs should be encoded as empty bytes")
-	t.Log(b)
+	var outer SomeStruct
+	cdc.UnmarshalBinaryBare(b, &outer)
+	assert.Equal(t, SomeStruct{}, outer, "")
+
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -103,3 +103,22 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 	// we still expect that decoding worked to some extend (until above error occurred):
 	assert.Equal(t, v1, V1{"tender", "cosmos"})
 }
+
+func TestWriteEmpty(t *testing.T) {
+	type Inner struct {
+		Val int
+	}
+	type SomeStruct struct {
+		Inner Inner
+	}
+
+	cdc := amino.NewCodec()
+	b, err := cdc.MarshalBinaryBare(Inner{})
+	assert.NoError(t, err)
+	assert.Equal(t, b, []byte(nil), "empty struct should be encoded as empty bytes")
+
+	b, err = cdc.MarshalBinaryBare(SomeStruct{})
+	assert.NoError(t, err)
+	assert.Equal(t, b, []byte(nil), "empty structs should be encoded as empty bytes")
+	t.Log(b)
+}

--- a/codec.go
+++ b/codec.go
@@ -506,8 +506,14 @@ func (cdc *Codec) parseFieldOptions(field reflect.StructField) (skip bool, fopts
 	}
 
 	// Parse amino tags.
-	if aminoTag == "unsafe" {
-		fopts.Unsafe = true
+	aminoTags := strings.Split(aminoTag, ",")
+	for _, aminoTag := range aminoTags {
+		if aminoTag == "unsafe" {
+			fopts.Unsafe = true
+		}
+		if aminoTag == "write_empty" {
+			fopts.WriteEmpty = true
+		}
 	}
 
 	return

--- a/codec.go
+++ b/codec.go
@@ -117,6 +117,7 @@ type FieldOptions struct {
 	BinFixed32    bool   // (Binary) Encode as fixed32
 	BinFieldNum   uint32 // (Binary) max 1<<29-1
 	Unsafe        bool   // e.g. if this field is a float.
+	WriteEmpty    bool   // write empty structs, default is to skip them
 }
 
 //----------------------------------------

--- a/tests/fuzz/binary/debug/main.go
+++ b/tests/fuzz/binary/debug/main.go
@@ -13,5 +13,5 @@ func main() {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
 	err := cdc.UnmarshalBinary(bz, &cst)
-	fmt.Println("Expected a panic but did not. (err: %v)", err)
+	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }

--- a/tests/fuzz/json/debug/main.go
+++ b/tests/fuzz/json/debug/main.go
@@ -13,5 +13,5 @@ func main() {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
 	err := cdc.UnmarshalJSON(bz, &cst)
-	fmt.Println("Expected a panic but did not. (err: %v)", err)
+	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }


### PR DESCRIPTION
- [x] encoding & basic tests 
- [x] decoding with writeEmpty set to true
- [x] more tests, testing, fuzzing