### PR TITLE
Fix another time decoding issue

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -444,3 +444,19 @@ func (cdc *Codec) MarshalJSONIndent(o interface{}, prefix, indent string) ([]byt
 	}
 	return out.Bytes(), nil
 }
+
+// Returns the default value of a type. For a time type or a pointer(s) to
+// time, the default value is not zero (or nil), but the time value of
+// 1970-01-01 00:00:00 +0000 UTC
+func defaultValue(rt reflect.Type) reflect.Value {
+	if rt == timeType {
+		return reflect.ValueOf(zeroTime)
+	}
+	if rt.Kind() == reflect.Ptr && rt.Elem() == timeType {
+		tPtr := reflect.New(timeType)
+		tPtr.Elem().Set(reflect.ValueOf(zeroTime))
+		return tPtr
+	}
+
+	return reflect.Zero(rt)
+}

--- a/binary-decode.go
+++ b/binary-decode.go
@@ -483,7 +483,12 @@ func (cdc *Codec) decodeReflectBinaryArray(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				erv.Set(reflect.Zero(erv.Type()))
+				if erv.Type() == timeType {
+					erv.Set(reflect.ValueOf(zeroTime))
+				} else {
+					erv.Set(reflect.Zero(erv.Type()))
+
+				}
 				continue
 			}
 			// Normal case, read next non-nil element from bz.
@@ -639,7 +644,11 @@ func (cdc *Codec) decodeReflectBinarySlice(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				erv.Set(reflect.Zero(erv.Type()))
+				if erv.Type() == timeType {
+					erv.Set(reflect.ValueOf(zeroTime))
+				} else {
+					erv.Set(reflect.Zero(erv.Type()))
+				}
 				srv = reflect.Append(srv, erv)
 				continue
 			}

--- a/binary-decode.go
+++ b/binary-decode.go
@@ -483,12 +483,7 @@ func (cdc *Codec) decodeReflectBinaryArray(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				if erv.Type() == timeType {
-					erv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					erv.Set(reflect.Zero(erv.Type()))
-
-				}
+				erv.Set(defaultValue(erv.Type()))
 				continue
 			}
 			// Normal case, read next non-nil element from bz.
@@ -644,11 +639,7 @@ func (cdc *Codec) decodeReflectBinarySlice(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				if erv.Type() == timeType {
-					erv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					erv.Set(reflect.Zero(erv.Type()))
-				}
+				erv.Set(defaultValue(erv.Type()))
 				srv = reflect.Append(srv, erv)
 				continue
 			}
@@ -722,11 +713,7 @@ func (cdc *Codec) decodeReflectBinaryStruct(bz []byte, info *TypeInfo, rv reflec
 
 			// We're done if we've consumed all the bytes.
 			if len(bz) == 0 {
-				if field.Type == timeType {
-					frv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					frv.Set(reflect.Zero(frv.Type()))
-				}
+				frv.Set(defaultValue(frv.Type()))
 				continue
 			}
 

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -396,22 +396,23 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 					return
 				}
 			} else {
-				lBefore := buf.Len()
+				lBeforeKey := buf.Len()
 				// Write field key (number and type).
 				err = encodeFieldNumberAndTyp3(buf, field.BinFieldNum, typeToTyp3(finfo.Type, field.FieldOptions))
 				if err != nil {
 					return
 				}
-				// Write field from rv.
+				lBeforeValue := buf.Len()
+				// Write field value from rv.
 				err = cdc.encodeReflectBinary(buf, finfo, frv, field.FieldOptions, false)
 				if err != nil {
 					return
 				}
-				lAfter := buf.Len()
+				lAfterValue := buf.Len()
 
-				if !fopts.WriteEmpty && lAfter == lBefore+2 && buf.Bytes()[buf.Len()-1] == 0x00 {
+				if !fopts.WriteEmpty && lBeforeValue == lAfterValue-1 && buf.Bytes()[buf.Len()-1] == 0x00 {
 					// rollback typ3/fieldnum and last byte if empty:
-					buf.Truncate(buf.Len() - 2)
+					buf.Truncate(lBeforeKey)
 				}
 			}
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"time"
 )
 
@@ -66,9 +65,6 @@ func DecodeVarint(bz []byte) (i int64, n int, err error) {
 	i, n = binary.Varint(bz)
 	if n == 0 {
 		// buf too small
-
-		debug.PrintStack()
-
 		err = errors.New("buffer too small")
 	} else if n < 0 {
 		// value larger than 64 bits (overflow)

--- a/time2_test.go
+++ b/time2_test.go
@@ -31,4 +31,23 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	err = cdc.UnmarshalBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
+
+	t1, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:11.577968799 +0000 UTC")
+	t2, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "2078-07-10 15:44:58.406865636 +0000 UTC")
+	t3, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
+	t4, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:14.48251984 +0000 UTC")
+
+	type tArr struct {
+		TimeAr [4]time.Time
+	}
+	st := tArr{
+		TimeAr: [4]time.Time{t1, t2, t3, t4},
+	}
+	b, err = cdc.MarshalBinary(st)
+	assert.NoError(t, err)
+
+	var tStruct tArr
+	err = cdc.UnmarshalBinary(b, &tStruct)
+	assert.NoError(t, err)
+	assert.Equal(t, st, tStruct)
 }

--- a/time2_test.go
+++ b/time2_test.go
@@ -41,7 +41,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 		TimeAr [4]time.Time
 	}
 	st := tArr{
-		TimeAr: [4]time.Time{time.Time{}, t2, t3, t4},
+		TimeAr: [4]time.Time{{}, t2, t3, t4},
 	}
 	b, err = cdc.MarshalBinary(st)
 	assert.NoError(t, err)
@@ -63,5 +63,4 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	err = cdc.UnmarshalBinary(b, &tPtrStr)
 	assert.NoError(t, err)
 	assert.Equal(t, ztp, tPtrStr)
-
 }

--- a/time2_test.go
+++ b/time2_test.go
@@ -32,7 +32,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
 
-	t1, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:11.577968799 +0000 UTC")
+	//t1, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:11.577968799 +0000 UTC")
 	t2, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "2078-07-10 15:44:58.406865636 +0000 UTC")
 	t3, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
 	t4, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:14.48251984 +0000 UTC")
@@ -41,7 +41,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 		TimeAr [4]time.Time
 	}
 	st := tArr{
-		TimeAr: [4]time.Time{t1, t2, t3, t4},
+		TimeAr: [4]time.Time{time.Time{}, t2, t3, t4},
 	}
 	b, err = cdc.MarshalBinary(st)
 	assert.NoError(t, err)
@@ -50,4 +50,18 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	err = cdc.UnmarshalBinary(b, &tStruct)
 	assert.NoError(t, err)
 	assert.Equal(t, st, tStruct)
+
+	type timePtr struct {
+		TimePtr *time.Time
+	}
+
+	ztp := timePtr{&tm}
+	b, err = cdc.MarshalBinary(ztp)
+	assert.NoError(t, err)
+
+	var tPtrStr timePtr
+	err = cdc.UnmarshalBinary(b, &tPtrStr)
+	assert.NoError(t, err)
+	assert.Equal(t, ztp, tPtrStr)
+
 }


### PR DESCRIPTION
This PR fixes the remaining cases (time in arrays, slices, pointers to time) where decoding time fails (if it was skipped over while encoding; introduced via #178).

Tests passed locally (incl. the fuzzer with no crashers for >1 hour). It still would be good to see circleci passing before this gets merged (see #200).

Thanks for the suggestions @jaekwon!

related to #189 #190 
resolves #189
Supersedes and closes #200 


