### PR TITLE
Alternative to #196

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -203,7 +203,7 @@ func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = cdc.encodeReflectBinary(buf, info, rv, FieldOptions{}, true)
+	err = cdc.encodeReflectBinary(buf, info, rv, FieldOptions{BinFieldNum: 1}, true)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 		bz = bz[4:]
 	}
 	// Decode contents into rv.
-	n, err := cdc.decodeReflectBinary(bz, info, rv, FieldOptions{}, true)
+	n, err := cdc.decodeReflectBinary(bz, info, rv, FieldOptions{BinFieldNum: 1}, true)
 	if err != nil {
 		return fmt.Errorf("unmarshal to %v failed after %d bytes (%v): %X", info.Type, n, err, bz)
 	}

--- a/binary-decode.go
+++ b/binary-decode.go
@@ -483,7 +483,12 @@ func (cdc *Codec) decodeReflectBinaryArray(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				erv.Set(reflect.Zero(erv.Type()))
+				if erv.Type() == timeType {
+					erv.Set(reflect.ValueOf(zeroTime))
+				} else {
+					erv.Set(reflect.Zero(erv.Type()))
+
+				}
 				continue
 			}
 			// Normal case, read next non-nil element from bz.
@@ -639,7 +644,11 @@ func (cdc *Codec) decodeReflectBinarySlice(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				erv.Set(reflect.Zero(erv.Type()))
+				if erv.Type() == timeType {
+					erv.Set(reflect.ValueOf(zeroTime))
+				} else {
+					erv.Set(reflect.Zero(erv.Type()))
+				}
 				srv = reflect.Append(srv, erv)
 				continue
 			}

--- a/binary-decode.go
+++ b/binary-decode.go
@@ -483,12 +483,7 @@ func (cdc *Codec) decodeReflectBinaryArray(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				if erv.Type() == timeType {
-					erv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					erv.Set(reflect.Zero(erv.Type()))
-
-				}
+				erv.Set(defaultValue(erv.Type()))
 				continue
 			}
 			// Normal case, read next non-nil element from bz.
@@ -644,11 +639,7 @@ func (cdc *Codec) decodeReflectBinarySlice(bz []byte, info *TypeInfo, rv reflect
 			// Special case if next ByteLength bytes are 0x00, set nil.
 			if len(bz) > 0 && bz[0] == 0x00 {
 				slide(&bz, &n, 1)
-				if erv.Type() == timeType {
-					erv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					erv.Set(reflect.Zero(erv.Type()))
-				}
+				erv.Set(defaultValue(erv.Type()))
 				srv = reflect.Append(srv, erv)
 				continue
 			}
@@ -722,11 +713,7 @@ func (cdc *Codec) decodeReflectBinaryStruct(bz []byte, info *TypeInfo, rv reflec
 
 			// We're done if we've consumed all the bytes.
 			if len(bz) == 0 {
-				if field.Type == timeType {
-					frv.Set(reflect.ValueOf(zeroTime))
-				} else {
-					frv.Set(reflect.Zero(frv.Type()))
-				}
+				frv.Set(defaultValue(frv.Type()))
 				continue
 			}
 
@@ -743,7 +730,7 @@ func (cdc *Codec) decodeReflectBinaryStruct(bz []byte, info *TypeInfo, rv reflec
 				fnum, typ, _n, err = decodeFieldNumberAndTyp3(bz)
 				if field.BinFieldNum < fnum {
 					// Set zero field value.
-					frv.Set(reflect.Zero(frv.Type()))
+					frv.Set(defaultValue(frv.Type()))
 					continue
 					// Do not slide, we will read it again.
 				}

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -103,12 +103,7 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 		err = EncodeInt8(w, int8(rv.Int()))
 
 	case reflect.Int:
-		buf := new(bytes.Buffer)
-		err = EncodeVarint(buf, rv.Int())
-		if err == nil {
-			_, err = w.Write(buf.Bytes())
-		}
-		//err = EncodeVarint(w, rv.Int())
+		err = EncodeVarint(w, rv.Int())
 
 	//----------------------------------------
 	// Unsigned

--- a/binary_test.go
+++ b/binary_test.go
@@ -1,11 +1,13 @@
 package amino_test
 
 import (
+	"fmt"
 	"testing"
+
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/go-amino"
-	"time"
 )
 
 func TestNilSliceEmptySlice(t *testing.T) {
@@ -150,4 +152,25 @@ func TestForceWriteEmpty(t *testing.T) {
 	t.Log(b)
 	// TODO(ismail): this alone won't be encoded:
 	//assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
+}
+
+func TestStructSlice(t *testing.T) {
+	type Foo struct {
+		A int
+		B int
+	}
+
+	type Foos []Foo
+
+	f := Foos{Foo{100, 101}, Foo{102, 103}}
+
+	cdc := amino.NewCodec()
+
+	bz, err := cdc.MarshalBinaryBare(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "0A0608C80110CA010A0608CC0110CE01", fmt.Sprintf("%X", bz))
+	t.Log(bz)
+	var f2 Foos
+	cdc.UnmarshalBinaryBare(bz, &f2)
+	assert.Equal(t, f, f2)
 }

--- a/reflect.go
+++ b/reflect.go
@@ -99,7 +99,7 @@ func derefPointersZero(rv reflect.Value) (drv reflect.Value, isPtr bool, isNilPt
 // Returns isDefaultValue=true iff is ultimately nil or empty after (recursive)
 // dereferencing. If isDefaultValue=false, erv is set to the non-nil non-empty
 // non-default dereferenced value.
-// A zero/empty struct is not considered default.
+// A zero/empty struct is not considered default for this function.
 func isDefaultValue(rv reflect.Value) (erv reflect.Value, isDefaultValue bool) {
 	rv, _, isNilPtr := derefPointers(rv)
 	if isNilPtr {
@@ -122,6 +122,47 @@ func isDefaultValue(rv reflect.Value) (erv reflect.Value, isDefaultValue bool) {
 			return rv, false
 		}
 	}
+}
+
+// Returns the default value of a type.  For a time type or a pointer(s) to
+// time, the default value is not zero (or nil), but the time value of 1970.
+func defaultValue(rt reflect.Type) (rv reflect.Value) {
+	switch rt.Kind() {
+	case reflect.Ptr:
+		// Dereference all the way and see if it's a time type.
+		rt_, indirects := rt.Elem(), 1
+		for rt_.Kind() == reflect.Ptr {
+			rt_ = rt_.Elem()
+			indirects += 1
+		}
+		switch rt_ {
+		case timeType:
+			// Start from the top and construct pointers as needed.
+			rv = reflect.New(rt).Elem()
+			rt_, rv_ := rt, rv
+			for rt_.Kind() == reflect.Ptr {
+				newPtr := reflect.New(rt_.Elem())
+				rv_.Set(newPtr)
+				rt_ = rt_.Elem()
+				rv_ = rv_.Elem()
+			}
+			// Set to 1970, the whole point of this function.
+			rv_.Set(reflect.ValueOf(zeroTime))
+			return rv
+		}
+	case reflect.Struct:
+		switch rt {
+		case timeType:
+			// Set to 1970, the whole point of this function.
+			rv = reflect.New(rt).Elem()
+			rv.Set(reflect.ValueOf(zeroTime))
+			return rv
+		}
+	}
+
+	// Just return ithe default Go zero object.
+	// Return an empty struct.
+	return reflect.Zero(rt)
 }
 
 func isNil(rv reflect.Value) bool {

--- a/time2_test.go
+++ b/time2_test.go
@@ -31,4 +31,23 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	err = cdc.UnmarshalBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
+
+	t1, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:11.577968799 +0000 UTC")
+	t2, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "2078-07-10 15:44:58.406865636 +0000 UTC")
+	t3, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
+	t4, _ := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:14.48251984 +0000 UTC")
+
+	type tArr struct {
+		TimeAr [4]time.Time
+	}
+	st := tArr{
+		TimeAr: [4]time.Time{t1, t2, t3, t4},
+	}
+	b, err = cdc.MarshalBinary(st)
+	assert.NoError(t, err)
+
+	var tStruct tArr
+	err = cdc.UnmarshalBinary(b, &tStruct)
+	assert.NoError(t, err)
+	assert.Equal(t, st, tStruct)
 }


### PR DESCRIPTION
edit by @Liamsi:
- "top-level entry functions should call with `BinFieldNum:1` to properly encode e.g. arrays of structs; a test is included"
- different from #196 defaultValue deals with multiply nested pointers 👍 

supersedes and closes #196 
supersedes and closes #200 