### PR TITLE
Allow nil (do not decode to empty struct) by default unless EmptyElements field tag is set

### DIFF
--- a/binary-decode.go
+++ b/binary-decode.go
@@ -484,9 +484,14 @@ func (cdc *Codec) decodeReflectBinaryArray(bz []byte, info *TypeInfo, rv reflect
 			}
 			// Decode the next ByteLength bytes into erv.
 			var erv = rv.Index(i)
-			// Special case if next ByteLength bytes are 0x00, and erv is not a
-			// struct pointer:
-			if !isErtStructPointer && (len(bz) > 0 && bz[0] == 0x00) {
+			// Special case if:
+			//  * next ByteLength bytes are 0x00, and
+			//  * - erv is not a struct pointer, or
+			//    - field option doesn't have EmptyElements set
+			// (the condition below uses demorgan's law)
+			if (len(bz) > 0 && bz[0] == 0x00) &&
+				!(isErtStructPointer && fopts.EmptyElements) {
+
 				slide(&bz, &n, 1)
 				erv.Set(defaultValue(erv.Type()))
 				continue
@@ -645,9 +650,14 @@ func (cdc *Codec) decodeReflectBinarySlice(bz []byte, info *TypeInfo, rv reflect
 			}
 			// Decode the next ByteLength bytes into erv.
 			erv, _n := reflect.New(ert).Elem(), int(0)
-			// Special case if next ByteLength bytes are 0x00, and erv is not a
-			// struct pointer:
-			if !isErtStructPointer && (len(bz) > 0 && bz[0] == 0x00) {
+			// Special case if:
+			//  * next ByteLength bytes are 0x00, and
+			//  * - erv is not a struct pointer, or
+			//    - field option doesn't have EmptyElements set
+			// (the condition below uses demorgan's law)
+			if (len(bz) > 0 && bz[0] == 0x00) &&
+				!(isErtStructPointer && fopts.EmptyElements) {
+
 				slide(&bz, &n, 1)
 				erv.Set(defaultValue(erv.Type()))
 				srv = reflect.Append(srv, erv)

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -310,14 +310,16 @@ func (cdc *Codec) encodeReflectBinaryList(w io.Writer, info *TypeInfo, rv reflec
 			// Get dereferenced element value and info.
 			var erv, isDefault = isDefaultValue(rv.Index(i))
 			if isDefault {
-				// Special case when rv is a struct pointer.
-				if isErtStructPointer {
+				// Special case if:
+				//  - erv is a struct pointer and
+				//  - field option has EmptyElements set
+				if isErtStructPointer && fopts.EmptyElements {
 					// NOTE: Not sure what to do here, but for future-proofing,
 					// we explicitly fail on nil pointers, just like
 					// Proto3's Golang client does.
 					// This also makes it easier to upgrade to Amino2
 					// which would enable the encoding of nil structs.
-					return errors.New("Amino1 doesn't support nil struct pointers")
+					return errors.New("nil struct pointers not supported when empty_elements field tag is set")
 				}
 				// Nothing to encode, so the length is 0.
 				err = EncodeByte(buf, byte(0x00))

--- a/binary_test.go
+++ b/binary_test.go
@@ -175,7 +175,7 @@ func TestStructSlice(t *testing.T) {
 	assert.Equal(t, f, f2)
 }
 
-func TestStructPointerSlice(t *testing.T) {
+func TestStructPointerSlice1(t *testing.T) {
 	cdc := amino.NewCodec()
 
 	type Foo struct {
@@ -192,7 +192,45 @@ func TestStructPointerSlice(t *testing.T) {
 		D: "j",
 	}
 	bz, err := cdc.MarshalBinary(f)
-	assert.Error(t, err, "we don't support encoding nil elements of a slice/array")
+	assert.NoError(t, err)
+
+	var f2 Foo
+	err = cdc.UnmarshalBinary(bz, &f2)
+	assert.Nil(t, err)
+
+	assert.Equal(t, f, f2)
+	assert.Nil(t, f2.C[0])
+
+	var f3 = Foo{
+		A: "k",
+		B: 2,
+		C: []*Foo{&Foo{}, &Foo{}, &Foo{}},
+		D: "j",
+	}
+	bz2, err := cdc.MarshalBinary(f3)
+	assert.NoError(t, err)
+	assert.Equal(t, bz, bz2, "empty slices should be decoded to nil unless empty_elements")
+}
+
+// Like TestStructPointerSlice2, but with EmptyElements.
+func TestStructPointerSlice2(t *testing.T) {
+	cdc := amino.NewCodec()
+
+	type Foo struct {
+		A string
+		B int
+		C []*Foo `amino:"empty_elements"`
+		D string // exposed
+	}
+
+	var f = Foo{
+		A: "k",
+		B: 2,
+		C: []*Foo{nil, nil, nil},
+		D: "j",
+	}
+	bz, err := cdc.MarshalBinary(f)
+	assert.Error(t, err, "nil elements of a slice/array not supported when empty_elements field tag set.")
 
 	f.C = []*Foo{&Foo{}, &Foo{}, &Foo{}}
 	bz, err = cdc.MarshalBinary(f)

--- a/binary_test.go
+++ b/binary_test.go
@@ -174,3 +174,34 @@ func TestStructSlice(t *testing.T) {
 	cdc.UnmarshalBinaryBare(bz, &f2)
 	assert.Equal(t, f, f2)
 }
+
+func TestStructPointerSlice(t *testing.T) {
+	cdc := amino.NewCodec()
+
+	type Foo struct {
+		A string
+		B int
+		C []*Foo
+		D string // exposed
+	}
+
+	var f = Foo{
+		A: "k",
+		B: 2,
+		C: []*Foo{nil, nil, nil},
+		D: "j",
+	}
+	bz, err := cdc.MarshalBinary(f)
+	assert.Error(t, err, "we don't support encoding nil elements of a slice/array")
+
+	f.C = []*Foo{&Foo{}, &Foo{}, &Foo{}}
+	bz, err = cdc.MarshalBinary(f)
+	assert.NoError(t, err)
+
+	var f2 Foo
+	err = cdc.UnmarshalBinary(bz, &f2)
+	assert.Nil(t, err)
+
+	assert.Equal(t, f, f2)
+	assert.NotNil(t, f2.C[0])
+}

--- a/codec.go
+++ b/codec.go
@@ -116,8 +116,10 @@ type FieldOptions struct {
 	BinFixed64    bool   // (Binary) Encode as fixed64
 	BinFixed32    bool   // (Binary) Encode as fixed32
 	BinFieldNum   uint32 // (Binary) max 1<<29-1
-	Unsafe        bool   // e.g. if this field is a float.
-	WriteEmpty    bool   // write empty structs and lists (default false except for pointers)
+
+	Unsafe        bool // e.g. if this field is a float.
+	WriteEmpty    bool // write empty structs and lists (default false except for pointers)
+	EmptyElements bool // Slice and Array elements are never nil, decode 0x00 as empty struct.
 }
 
 //----------------------------------------
@@ -513,6 +515,9 @@ func (cdc *Codec) parseFieldOptions(field reflect.StructField) (skip bool, fopts
 		}
 		if aminoTag == "write_empty" {
 			fopts.WriteEmpty = true
+		}
+		if aminoTag == "empty_elements" {
+			fopts.EmptyElements = true
 		}
 	}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -524,6 +524,20 @@ var fuzzFuncs = []interface{}{
 		// Also set to UTC.
 		*tyme = tyme.Truncate(0).UTC()
 	},
+	func(esz *[]*tests.EmptyStruct, c fuzz.Continue) {
+		n := c.Intn(4)
+		switch n {
+		case 0:
+			// Prefer nil over empty slice.
+			*esz = nil
+		default:
+			// Slice of struct pointers should not be nil.
+			*esz = make([]*tests.EmptyStruct, n)
+			for i := 0; i < n; i++ {
+				(*esz)[i] = &tests.EmptyStruct{}
+			}
+		}
+	},
 }
 
 //----------------------------------------

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -531,10 +531,11 @@ var fuzzFuncs = []interface{}{
 			// Prefer nil over empty slice.
 			*esz = nil
 		default:
-			// Slice of struct pointers should not be nil.
+			// Slice of empty struct pointers should be nil,
+			// since we don't set amino:"empty_elements".
 			*esz = make([]*tests.EmptyStruct, n)
 			for i := 0; i < n; i++ {
-				(*esz)[i] = &tests.EmptyStruct{}
+				(*esz)[i] = nil
 			}
 		}
 	},

--- a/repr_test.go
+++ b/repr_test.go
@@ -54,7 +54,7 @@ func TestMarshalAminoBinary(t *testing.T) {
 	var f = Foo{
 		a: "K",
 		b: 2,
-		c: []*Foo{nil, nil, nil},
+		c: []*Foo{&Foo{}, &Foo{}, &Foo{}},
 		D: "J",
 	}
 	bz, err := cdc.MarshalBinary(f)
@@ -81,7 +81,7 @@ func TestMarshalAminoJSON(t *testing.T) {
 	var f = Foo{
 		a: "K",
 		b: 2,
-		c: []*Foo{nil, nil, nil},
+		c: []*Foo{&Foo{}, &Foo{}, &Foo{}},
 		D: "J",
 	}
 	bz, err := cdc.MarshalJSON(f)

--- a/repr_test.go
+++ b/repr_test.go
@@ -54,7 +54,7 @@ func TestMarshalAminoBinary(t *testing.T) {
 	var f = Foo{
 		a: "K",
 		b: 2,
-		c: []*Foo{&Foo{}, &Foo{}, &Foo{}},
+		c: []*Foo{nil, nil, nil},
 		D: "J",
 	}
 	bz, err := cdc.MarshalBinary(f)
@@ -81,7 +81,7 @@ func TestMarshalAminoJSON(t *testing.T) {
 	var f = Foo{
 		a: "K",
 		b: 2,
-		c: []*Foo{&Foo{}, &Foo{}, &Foo{}},
+		c: []*Foo{nil, nil, nil},
 		D: "J",
 	}
 	bz, err := cdc.MarshalJSON(f)


### PR DESCRIPTION
Tendermint requires support for nil (instead of empty) struct pointers, e.g. for Commit and ValidatorSet.  This change reverts writeemptyptr to the default behavior, except when amino:"EmptyElements" field tag is set.