### PR TITLE
Make MarshalBinary the non-length prefixed default

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -32,16 +32,16 @@ func init() {
 	}
 }
 
-func MarshalBinary(o interface{}) ([]byte, error) {
-	return gcdc.MarshalBinary(o)
+func MarshalBinaryLengthPrefixed(o interface{}) ([]byte, error) {
+	return gcdc.MarshalBinaryLengthPrefixed(o)
 }
 
-func MarshalBinaryWriter(w io.Writer, o interface{}) (n int64, err error) {
-	return gcdc.MarshalBinaryWriter(w, o)
+func MarshalBinaryLengthPrefixedWriter(w io.Writer, o interface{}) (n int64, err error) {
+	return gcdc.MarshalBinaryLengthPrefixedWriter(w, o)
 }
 
-func MustMarshalBinary(o interface{}) []byte {
-	return gcdc.MustMarshalBinary(o)
+func MustMarshalBinaryLengthPrefixed(o interface{}) []byte {
+	return gcdc.MustMarshalBinaryLengthPrefixed(o)
 }
 
 func MarshalBinaryBare(o interface{}) ([]byte, error) {
@@ -52,16 +52,16 @@ func MustMarshalBinaryBare(o interface{}) []byte {
 	return gcdc.MustMarshalBinaryBare(o)
 }
 
-func UnmarshalBinary(bz []byte, ptr interface{}) error {
-	return gcdc.UnmarshalBinary(bz, ptr)
+func UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) error {
+	return gcdc.UnmarshalBinaryLengthPrefixedBinary(bz, ptr)
 }
 
-func UnmarshalBinaryReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
-	return gcdc.UnmarshalBinaryReader(r, ptr, maxSize)
+func UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
+	return gcdc.UnmarshalBinaryLengthPrefixedReader(r, ptr, maxSize)
 }
 
-func MustUnmarshalBinary(bz []byte, ptr interface{}) {
-	gcdc.MustUnmarshalBinary(bz, ptr)
+func MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) {
+	gcdc.MustUnmarshalBinaryLengthPrefixed(bz, ptr)
 }
 
 func UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
@@ -127,14 +127,14 @@ func (typ Typ3) String() string {
 //----------------------------------------
 // *Codec methods
 
-// MarshalBinary encodes the object o according to the Amino spec,
+// MarshalBinaryLengthPrefixed encodes the object o according to the Amino spec,
 // but prefixed by a uvarint encoding of the object to encode.
 // Use MarshalBinaryBare if you don't want byte-length prefixing.
 //
-// For consistency, MarshalBinary will first dereference pointers
-// before encoding.  MarshalBinary will panic if o is a nil-pointer,
+// For consistency, MarshalBinaryLengthPrefixed will first dereference pointers
+// before encoding.  MarshalBinaryLengthPrefixed will panic if o is a nil-pointer,
 // or if o is invalid.
-func (cdc *Codec) MarshalBinary(o interface{}) ([]byte, error) {
+func (cdc *Codec) MarshalBinaryLengthPrefixed(o interface{}) ([]byte, error) {
 
 	// Write the bytes here.
 	var buf = new(bytes.Buffer)
@@ -160,11 +160,11 @@ func (cdc *Codec) MarshalBinary(o interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// MarshalBinaryWriter writes the bytes as would be returned from
-// MarshalBinary to the writer w.
-func (cdc *Codec) MarshalBinaryWriter(w io.Writer, o interface{}) (n int64, err error) {
+// MarshalBinaryLengthPrefixedWriter writes the bytes as would be returned from
+// MarshalBinaryLengthPrefixed to the writer w.
+func (cdc *Codec) MarshalBinaryLengthPrefixedWriter(w io.Writer, o interface{}) (n int64, err error) {
 	var bz, _n = []byte(nil), int(0)
-	bz, err = cdc.MarshalBinary(o)
+	bz, err = cdc.MarshalBinaryLengthPrefixed(o)
 	if err != nil {
 		return 0, err
 	}
@@ -174,8 +174,8 @@ func (cdc *Codec) MarshalBinaryWriter(w io.Writer, o interface{}) (n int64, err 
 }
 
 // Panics if error.
-func (cdc *Codec) MustMarshalBinary(o interface{}) []byte {
-	bz, err := cdc.MarshalBinary(o)
+func (cdc *Codec) MustMarshalBinaryLengthPrefixed(o interface{}) []byte {
+	bz, err := cdc.MarshalBinaryLengthPrefixed(o)
 	if err != nil {
 		panic(err)
 	}
@@ -191,8 +191,8 @@ func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 	var rv, _, isNilPtr = derefPointers(reflect.ValueOf(o))
 	if isNilPtr {
 		// NOTE: You can still do so by calling
-		// `.MarshalBinary(struct{ *SomeType })` or so on.
-		panic("MarshalBinary cannot marshal a nil pointer directly. Try wrapping in a struct?")
+		// `.MarshalBinaryLengthPrefixed(struct{ *SomeType })` or so on.
+		panic("MarshalBinaryBare cannot marshal a nil pointer directly. Try wrapping in a struct?")
 	}
 
 	// Encode Amino:binary bytes.
@@ -228,11 +228,11 @@ func (cdc *Codec) MustMarshalBinaryBare(o interface{}) []byte {
 }
 
 // Like UnmarshalBinaryBare, but will first decode the byte-length prefix.
-// UnmarshalBinary will panic if ptr is a nil-pointer.
+// UnmarshalBinaryLengthPrefixedBinary will panic if ptr is a nil-pointer.
 // Returns an error if not all of bz is consumed.
-func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
+func (cdc *Codec) UnmarshalBinaryLengthPrefixedBinary(bz []byte, ptr interface{}) error {
 	if len(bz) == 0 {
-		return errors.New("UnmarshalBinary cannot decode empty bytes")
+		return errors.New("UnmarshalBinaryLengthPrefixedBinary cannot decode empty bytes")
 	}
 
 	// Read byte-length prefix.
@@ -241,10 +241,10 @@ func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
 		return fmt.Errorf("Error reading msg byte-length prefix: got code %v", n)
 	}
 	if u64 > uint64(len(bz)-n) {
-		return fmt.Errorf("Not enough bytes to read in UnmarshalBinary, want %v more bytes but only have %v",
+		return fmt.Errorf("Not enough bytes to read in UnmarshalBinaryLengthPrefixedBinary, want %v more bytes but only have %v",
 			u64, len(bz)-n)
 	} else if u64 < uint64(len(bz)-n) {
-		return fmt.Errorf("Bytes left over in UnmarshalBinary, should read %v more bytes but have %v",
+		return fmt.Errorf("Bytes left over in UnmarshalBinaryLengthPrefixedBinary, should read %v more bytes but have %v",
 			u64, len(bz)-n)
 	}
 	bz = bz[n:]
@@ -254,9 +254,9 @@ func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
 }
 
 // Like UnmarshalBinaryBare, but will first read the byte-length prefix.
-// UnmarshalBinaryReader will panic if ptr is a nil-pointer.
+// UnmarshalBinaryLengthPrefixedReader will panic if ptr is a nil-pointer.
 // If maxSize is 0, there is no limit (not recommended).
-func (cdc *Codec) UnmarshalBinaryReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
+func (cdc *Codec) UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
 	if maxSize < 0 {
 		panic("maxSize cannot be negative.")
 	}
@@ -310,8 +310,8 @@ func (cdc *Codec) UnmarshalBinaryReader(r io.Reader, ptr interface{}, maxSize in
 }
 
 // Panics if error.
-func (cdc *Codec) MustUnmarshalBinary(bz []byte, ptr interface{}) {
-	err := cdc.UnmarshalBinary(bz, ptr)
+func (cdc *Codec) MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) {
+	err := cdc.UnmarshalBinaryLengthPrefixedBinary(bz, ptr)
 	if err != nil {
 		panic(err)
 	}

--- a/amino.go
+++ b/amino.go
@@ -32,44 +32,44 @@ func init() {
 	}
 }
 
-func MarshalBinaryLengthPrefixed(o interface{}) ([]byte, error) {
-	return gcdc.MarshalBinaryLengthPrefixed(o)
-}
-
-func MarshalBinaryLengthPrefixedWriter(w io.Writer, o interface{}) (n int64, err error) {
-	return gcdc.MarshalBinaryLengthPrefixedWriter(w, o)
-}
-
-func MustMarshalBinaryLengthPrefixed(o interface{}) []byte {
-	return gcdc.MustMarshalBinaryLengthPrefixed(o)
-}
-
 func MarshalBinary(o interface{}) ([]byte, error) {
 	return gcdc.MarshalBinary(o)
+}
+
+func MarshalBinaryWriter(w io.Writer, o interface{}) (n int64, err error) {
+	return gcdc.MarshalBinaryWriter(w, o)
 }
 
 func MustMarshalBinary(o interface{}) []byte {
 	return gcdc.MustMarshalBinary(o)
 }
 
-func UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) error {
-	return gcdc.UnmarshalBinaryLengthPrefixed(bz, ptr)
+func MarshalBinaryBare(o interface{}) ([]byte, error) {
+	return gcdc.MarshalBinaryBare(o)
 }
 
-func UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
-	return gcdc.UnmarshalBinaryLengthPrefixedReader(r, ptr, maxSize)
-}
-
-func MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) {
-	gcdc.MustUnmarshalBinaryLengthPrefixed(bz, ptr)
+func MustMarshalBinaryBare(o interface{}) []byte {
+	return gcdc.MustMarshalBinaryBare(o)
 }
 
 func UnmarshalBinary(bz []byte, ptr interface{}) error {
 	return gcdc.UnmarshalBinary(bz, ptr)
 }
 
+func UnmarshalBinaryReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
+	return gcdc.UnmarshalBinaryReader(r, ptr, maxSize)
+}
+
 func MustUnmarshalBinary(bz []byte, ptr interface{}) {
 	gcdc.MustUnmarshalBinary(bz, ptr)
+}
+
+func UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
+	return gcdc.UnmarshalBinaryBare(bz, ptr)
+}
+
+func MustUnmarshalBinaryBare(bz []byte, ptr interface{}) {
+	gcdc.MustUnmarshalBinaryBare(bz, ptr)
 }
 
 func MarshalJSON(o interface{}) ([]byte, error) {
@@ -127,20 +127,20 @@ func (typ Typ3) String() string {
 //----------------------------------------
 // *Codec methods
 
-// MarshalBinaryLengthPrefixed encodes the object o according to the Amino spec,
+// MarshalBinary encodes the object o according to the Amino spec,
 // but prefixed by a uvarint encoding of the object to encode.
-// Use MarshalBinary if you don't want byte-length prefixing.
+// Use MarshalBinaryBare if you don't want byte-length prefixing.
 //
-// For consistency, MarshalBinaryLengthPrefixed will first dereference pointers
-// before encoding.  MarshalBinaryLengthPrefixed will panic if o is a nil-pointer,
+// For consistency, MarshalBinary will first dereference pointers
+// before encoding.  MarshalBinary will panic if o is a nil-pointer,
 // or if o is invalid.
-func (cdc *Codec) MarshalBinaryLengthPrefixed(o interface{}) ([]byte, error) {
+func (cdc *Codec) MarshalBinary(o interface{}) ([]byte, error) {
 
 	// Write the bytes here.
 	var buf = new(bytes.Buffer)
 
 	// Write the bz without length-prefixing.
-	bz, err := cdc.MarshalBinary(o)
+	bz, err := cdc.MarshalBinaryBare(o)
 	if err != nil {
 		return nil, err
 	}
@@ -160,11 +160,11 @@ func (cdc *Codec) MarshalBinaryLengthPrefixed(o interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// MarshalBinaryLengthPrefixedWriter writes the bytes as would be returned from
-// MarshalBinaryLengthPrefixed to the writer w.
-func (cdc *Codec) MarshalBinaryLengthPrefixedWriter(w io.Writer, o interface{}) (n int64, err error) {
+// MarshalBinaryWriter writes the bytes as would be returned from
+// MarshalBinary to the writer w.
+func (cdc *Codec) MarshalBinaryWriter(w io.Writer, o interface{}) (n int64, err error) {
 	var bz, _n = []byte(nil), int(0)
-	bz, err = cdc.MarshalBinaryLengthPrefixed(o)
+	bz, err = cdc.MarshalBinary(o)
 	if err != nil {
 		return 0, err
 	}
@@ -174,24 +174,24 @@ func (cdc *Codec) MarshalBinaryLengthPrefixedWriter(w io.Writer, o interface{}) 
 }
 
 // Panics if error.
-func (cdc *Codec) MustMarshalBinaryLengthPrefixed(o interface{}) []byte {
-	bz, err := cdc.MarshalBinaryLengthPrefixed(o)
+func (cdc *Codec) MustMarshalBinary(o interface{}) []byte {
+	bz, err := cdc.MarshalBinary(o)
 	if err != nil {
 		panic(err)
 	}
 	return bz
 }
 
-// MarshalBinary encodes the object o according to the Amino spec.
-// MarshalBinary doesn't prefix the byte-length of the encoding,
+// MarshalBinaryBare encodes the object o according to the Amino spec.
+// MarshalBinaryBare doesn't prefix the byte-length of the encoding,
 // so the caller must handle framing.
-func (cdc *Codec) MarshalBinary(o interface{}) ([]byte, error) {
+func (cdc *Codec) MarshalBinaryBare(o interface{}) ([]byte, error) {
 
 	// Dereference value if pointer.
 	var rv, _, isNilPtr = derefPointers(reflect.ValueOf(o))
 	if isNilPtr {
 		// NOTE: You can still do so by calling
-		// `.MarshalBinaryLengthPrefixed(struct{ *SomeType })` or so on.
+		// `.MarshalBinary(struct{ *SomeType })` or so on.
 		panic("MarshalBinary cannot marshal a nil pointer directly. Try wrapping in a struct?")
 	}
 
@@ -219,20 +219,20 @@ func (cdc *Codec) MarshalBinary(o interface{}) ([]byte, error) {
 }
 
 // Panics if error.
-func (cdc *Codec) MustMarshalBinary(o interface{}) []byte {
-	bz, err := cdc.MarshalBinary(o)
+func (cdc *Codec) MustMarshalBinaryBare(o interface{}) []byte {
+	bz, err := cdc.MarshalBinaryBare(o)
 	if err != nil {
 		panic(err)
 	}
 	return bz
 }
 
-// Like UnmarshalBinary, but will first decode the byte-length prefix.
-// UnmarshalBinaryLengthPrefixed will panic if ptr is a nil-pointer.
+// Like UnmarshalBinaryBare, but will first decode the byte-length prefix.
+// UnmarshalBinary will panic if ptr is a nil-pointer.
 // Returns an error if not all of bz is consumed.
-func (cdc *Codec) UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) error {
+func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
 	if len(bz) == 0 {
-		return errors.New("UnmarshalBinaryLengthPrefixed cannot decode empty bytes")
+		return errors.New("UnmarshalBinary cannot decode empty bytes")
 	}
 
 	// Read byte-length prefix.
@@ -241,22 +241,22 @@ func (cdc *Codec) UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) erro
 		return fmt.Errorf("Error reading msg byte-length prefix: got code %v", n)
 	}
 	if u64 > uint64(len(bz)-n) {
-		return fmt.Errorf("Not enough bytes to read in UnmarshalBinaryLengthPrefixed, want %v more bytes but only have %v",
+		return fmt.Errorf("Not enough bytes to read in UnmarshalBinary, want %v more bytes but only have %v",
 			u64, len(bz)-n)
 	} else if u64 < uint64(len(bz)-n) {
-		return fmt.Errorf("Bytes left over in UnmarshalBinaryLengthPrefixed, should read %v more bytes but have %v",
+		return fmt.Errorf("Bytes left over in UnmarshalBinary, should read %v more bytes but have %v",
 			u64, len(bz)-n)
 	}
 	bz = bz[n:]
 
 	// Decode.
-	return cdc.UnmarshalBinary(bz, ptr)
+	return cdc.UnmarshalBinaryBare(bz, ptr)
 }
 
-// Like UnmarshalBinary, but will first read the byte-length prefix.
-// UnmarshalBinaryLengthPrefixedReader will panic if ptr is a nil-pointer.
+// Like UnmarshalBinaryBare, but will first read the byte-length prefix.
+// UnmarshalBinaryReader will panic if ptr is a nil-pointer.
 // If maxSize is 0, there is no limit (not recommended).
-func (cdc *Codec) UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
+func (cdc *Codec) UnmarshalBinaryReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
 	if maxSize < 0 {
 		panic("maxSize cannot be negative.")
 	}
@@ -305,20 +305,20 @@ func (cdc *Codec) UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface
 	n += l
 
 	// Decode.
-	err = cdc.UnmarshalBinary(bz, ptr)
+	err = cdc.UnmarshalBinaryBare(bz, ptr)
 	return
 }
 
 // Panics if error.
-func (cdc *Codec) MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) {
-	err := cdc.UnmarshalBinaryLengthPrefixed(bz, ptr)
+func (cdc *Codec) MustUnmarshalBinary(bz []byte, ptr interface{}) {
+	err := cdc.UnmarshalBinary(bz, ptr)
 	if err != nil {
 		panic(err)
 	}
 }
 
-// UnmarshalBinary will panic if ptr is a nil-pointer.
-func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
+// UnmarshalBinaryBare will panic if ptr is a nil-pointer.
+func (cdc *Codec) UnmarshalBinaryBare(bz []byte, ptr interface{}) error {
 
 	rv := reflect.ValueOf(ptr)
 	if rv.Kind() != reflect.Ptr {
@@ -334,9 +334,9 @@ func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
 	if info.Registered {
 		pb := info.Prefix.Bytes()
 		if len(bz) < 4 {
-			return fmt.Errorf("UnmarshalBinary expected to read prefix bytes %X (since it is registered concrete) but got %X", pb, bz)
+			return fmt.Errorf("UnmarshalBinaryBare expected to read prefix bytes %X (since it is registered concrete) but got %X", pb, bz)
 		} else if !bytes.Equal(bz[:4], pb) {
-			return fmt.Errorf("UnmarshalBinary expected to read prefix bytes %X (since it is registered concrete) but got %X...", pb, bz[:4])
+			return fmt.Errorf("UnmarshalBinaryBare expected to read prefix bytes %X (since it is registered concrete) but got %X...", pb, bz[:4])
 		}
 		bz = bz[4:]
 	}
@@ -352,8 +352,8 @@ func (cdc *Codec) UnmarshalBinary(bz []byte, ptr interface{}) error {
 }
 
 // Panics if error.
-func (cdc *Codec) MustUnmarshalBinary(bz []byte, ptr interface{}) {
-	err := cdc.UnmarshalBinary(bz, ptr)
+func (cdc *Codec) MustUnmarshalBinaryBare(bz []byte, ptr interface{}) {
+	err := cdc.UnmarshalBinaryBare(bz, ptr)
 	if err != nil {
 		panic(err)
 	}

--- a/amino_test.go
+++ b/amino_test.go
@@ -24,12 +24,12 @@ func TestMarshalBinary(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2)
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 }
@@ -49,12 +49,12 @@ func TestUnmarshalBinaryReader(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 
 	assert.Equal(t, s, s2)
@@ -64,13 +64,13 @@ func TestUnmarshalBinaryReaderSize(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinary(s1)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -81,15 +81,15 @@ func TestUnmarshalBinaryReaderSizeLimit(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinary(s1)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
 	assert.NotNil(t, err, "insufficient limit should lead to failure")
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)))
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)))
 	assert.Nil(t, err, "sufficient limit should not cause failure")
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -111,12 +111,12 @@ func TestUnmarshalBinaryReaderTooLong(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
 	assert.NotNil(t, err)
 }
 
@@ -126,26 +126,26 @@ func TestUnmarshalBinaryBufferedWritesReads(t *testing.T) {
 
 	// Write 3 times.
 	var s1 string = "foo"
-	_, err := cdc.MarshalBinaryWriter(buf, s1)
+	_, err := cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryWriter(buf, s1)
+	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryWriter(buf, s1)
+	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
 
 	// Read 3 times.
 	var s2 string
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 
 	// Reading 4th time fails.
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.NotNil(t, err)
 }

--- a/amino_test.go
+++ b/amino_test.go
@@ -24,12 +24,12 @@ func TestMarshalBinary(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2)
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 }
@@ -49,12 +49,12 @@ func TestUnmarshalBinaryReader(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 
 	assert.Equal(t, s, s2)
@@ -64,13 +64,13 @@ func TestUnmarshalBinaryReaderSize(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinary(s1)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -81,15 +81,15 @@ func TestUnmarshalBinaryReaderSizeLimit(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinary(s1)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
 	assert.NotNil(t, err, "insufficient limit should lead to failure")
-	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)))
+	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)))
 	assert.Nil(t, err, "sufficient limit should not cause failure")
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -111,12 +111,12 @@ func TestUnmarshalBinaryReaderTooLong(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinary(s)
+	b, err := cdc.MarshalBinaryLengthPrefixed(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinary(s) -> %X", b)
+	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
 	assert.NotNil(t, err)
 }
 
@@ -126,26 +126,26 @@ func TestUnmarshalBinaryBufferedWritesReads(t *testing.T) {
 
 	// Write 3 times.
 	var s1 string = "foo"
-	_, err := cdc.MarshalBinaryWriter(buf, s1)
+	_, err := cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryWriter(buf, s1)
+	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryWriter(buf, s1)
+	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
 	assert.Nil(t, err)
 
 	// Read 3 times.
 	var s2 string
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 
 	// Reading 4th time fails.
-	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
 	assert.NotNil(t, err)
 }

--- a/amino_test.go
+++ b/amino_test.go
@@ -24,12 +24,12 @@ func TestMarshalBinary(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinaryLengthPrefixed(s)
+	b, err := cdc.MarshalBinary(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
+	t.Logf("MarshalBinary(s) -> %X", b)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2)
+	err = cdc.UnmarshalBinary(b, &s2)
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 }
@@ -49,12 +49,12 @@ func TestUnmarshalBinaryReader(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinaryLengthPrefixed(s)
+	b, err := cdc.MarshalBinary(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
+	t.Logf("MarshalBinary(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
+	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 
 	assert.Equal(t, s, s2)
@@ -64,13 +64,13 @@ func TestUnmarshalBinaryReaderSize(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
+	b, err := cdc.MarshalBinary(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
+	t.Logf("MarshalBinary(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 0)
+	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -81,15 +81,15 @@ func TestUnmarshalBinaryReaderSizeLimit(t *testing.T) {
 	var cdc = amino.NewCodec()
 
 	var s1 string = "foo"
-	b, err := cdc.MarshalBinaryLengthPrefixed(s1)
+	b, err := cdc.MarshalBinary(s1)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
+	t.Logf("MarshalBinary(s) -> %X", b)
 
 	var s2 string
 	var n int64
-	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
+	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)-1))
 	assert.NotNil(t, err, "insufficient limit should lead to failure")
-	n, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, int64(len(b)))
+	n, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, int64(len(b)))
 	assert.Nil(t, err, "sufficient limit should not cause failure")
 	assert.Equal(t, s1, s2)
 	frameLengthBytes, msgLengthBytes := 1, 1
@@ -111,12 +111,12 @@ func TestUnmarshalBinaryReaderTooLong(t *testing.T) {
 		Time:   time.Now().UTC().Truncate(time.Millisecond), // strip monotonic and timezone.
 	}
 
-	b, err := cdc.MarshalBinaryLengthPrefixed(s)
+	b, err := cdc.MarshalBinary(s)
 	assert.Nil(t, err)
-	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
+	t.Logf("MarshalBinary(s) -> %X", b)
 
 	var s2 SimpleStruct
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
+	_, err = cdc.UnmarshalBinaryReader(bytes.NewBuffer(b), &s2, 1) // 1 byte limit is ridiculous.
 	assert.NotNil(t, err)
 }
 
@@ -126,26 +126,26 @@ func TestUnmarshalBinaryBufferedWritesReads(t *testing.T) {
 
 	// Write 3 times.
 	var s1 string = "foo"
-	_, err := cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
+	_, err := cdc.MarshalBinaryWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
+	_, err = cdc.MarshalBinaryWriter(buf, s1)
 	assert.Nil(t, err)
-	_, err = cdc.MarshalBinaryLengthPrefixedWriter(buf, s1)
+	_, err = cdc.MarshalBinaryWriter(buf, s1)
 	assert.Nil(t, err)
 
 	// Read 3 times.
 	var s2 string
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, s1, s2)
 
 	// Reading 4th time fails.
-	_, err = cdc.UnmarshalBinaryLengthPrefixedReader(buf, &s2, 0)
+	_, err = cdc.UnmarshalBinaryReader(buf, &s2, 0)
 	assert.NotNil(t, err)
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -49,9 +49,9 @@ func TestNilSliceEmptySlice(t *testing.T) {
 		F: []*[]int{&eei},
 	}
 
-	abz := cdc.MustMarshalBinary(a)
-	bbz := cdc.MustMarshalBinary(b)
-	cbz := cdc.MustMarshalBinary(c)
+	abz := cdc.MustMarshalBinaryLengthPrefixed(a)
+	bbz := cdc.MustMarshalBinaryLengthPrefixed(b)
+	cbz := cdc.MustMarshalBinaryLengthPrefixed(c)
 
 	assert.Equal(t, abz, bbz, "a != b")
 	assert.Equal(t, abz, cbz, "a != c")
@@ -191,11 +191,11 @@ func TestStructPointerSlice1(t *testing.T) {
 		C: []*Foo{nil, nil, nil},
 		D: "j",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)
@@ -207,7 +207,7 @@ func TestStructPointerSlice1(t *testing.T) {
 		C: []*Foo{&Foo{}, &Foo{}, &Foo{}},
 		D: "j",
 	}
-	bz2, err := cdc.MarshalBinary(f3)
+	bz2, err := cdc.MarshalBinaryLengthPrefixed(f3)
 	assert.NoError(t, err)
 	assert.Equal(t, bz, bz2, "empty slices should be decoded to nil unless empty_elements")
 }
@@ -229,15 +229,15 @@ func TestStructPointerSlice2(t *testing.T) {
 		C: []*Foo{nil, nil, nil},
 		D: "j",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.Error(t, err, "nil elements of a slice/array not supported when empty_elements field tag set.")
 
 	f.C = []*Foo{&Foo{}, &Foo{}, &Foo{}}
-	bz, err = cdc.MarshalBinary(f)
+	bz, err = cdc.MarshalBinaryLengthPrefixed(f)
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/binary_test.go
+++ b/binary_test.go
@@ -49,9 +49,9 @@ func TestNilSliceEmptySlice(t *testing.T) {
 		F: []*[]int{&eei},
 	}
 
-	abz := cdc.MustMarshalBinary(a)
-	bbz := cdc.MustMarshalBinary(b)
-	cbz := cdc.MustMarshalBinary(c)
+	abz := cdc.MustMarshalBinaryLengthPrefixed(a)
+	bbz := cdc.MustMarshalBinaryLengthPrefixed(b)
+	cbz := cdc.MustMarshalBinaryLengthPrefixed(c)
 
 	assert.Equal(t, abz, bbz, "a != b")
 	assert.Equal(t, abz, cbz, "a != c")
@@ -85,20 +85,20 @@ func TestNewFieldBackwardsCompatibility(t *testing.T) {
 	cdc := amino.NewCodec()
 	notNow, _ := time.Parse("2006-01-02", "1934-11-09")
 	v2 := V2{String: "hi", String2: "cosmos", Time: notNow, Int: 4}
-	bz, err := cdc.MarshalBinaryBare(v2)
+	bz, err := cdc.MarshalBinary(v2)
 	assert.Nil(t, err, "unexpected error while encoding V2: %v", err)
 
 	var v1 V1
-	err = cdc.UnmarshalBinaryBare(bz, &v1)
+	err = cdc.UnmarshalBinary(bz, &v1)
 	assert.Nil(t, err, "unexpected error %v", err)
 	assert.Equal(t, v1, V1{"hi", "cosmos"},
 		"backwards compatibility failed: didn't yield expected result ...")
 
 	v3 := V3{String: "tender", Int: 2014, Some: SomeStruct{Sth: 84}}
-	bz2, err := cdc.MarshalBinaryBare(v3)
+	bz2, err := cdc.MarshalBinary(v3)
 	assert.Nil(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(bz2, &v1)
+	err = cdc.UnmarshalBinary(bz2, &v1)
 	// this might change later but we include this case to document the current behaviour:
 	assert.NotNil(t, err, "expected an error here because of changed order of fields")
 
@@ -115,18 +115,18 @@ func TestWriteEmpty(t *testing.T) {
 	}
 
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryBare(Inner{})
+	b, err := cdc.MarshalBinary(Inner{})
 	assert.NoError(t, err)
 	assert.Equal(t, b, []byte(nil), "empty struct should be encoded as empty bytes")
 	var inner Inner
-	cdc.UnmarshalBinaryBare(b, &inner)
+	cdc.UnmarshalBinary(b, &inner)
 	assert.Equal(t, Inner{}, inner, "")
 
-	b, err = cdc.MarshalBinaryBare(SomeStruct{})
+	b, err = cdc.MarshalBinary(SomeStruct{})
 	assert.NoError(t, err)
 	assert.Equal(t, b, []byte(nil), "empty structs should be encoded as empty bytes")
 	var outer SomeStruct
-	cdc.UnmarshalBinaryBare(b, &outer)
+	cdc.UnmarshalBinary(b, &outer)
 	assert.Equal(t, SomeStruct{}, outer, "")
 }
 
@@ -143,11 +143,11 @@ func TestForceWriteEmpty(t *testing.T) {
 
 	cdc := amino.NewCodec()
 
-	b, err := cdc.MarshalBinaryBare(OuterWriteEmpty{})
+	b, err := cdc.MarshalBinary(OuterWriteEmpty{})
 	assert.NoError(t, err)
 	assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
 
-	b, err = cdc.MarshalBinaryBare(InnerWriteEmpty{})
+	b, err = cdc.MarshalBinary(InnerWriteEmpty{})
 	assert.NoError(t, err)
 	t.Log(b)
 	// TODO(ismail): this alone won't be encoded:
@@ -166,12 +166,12 @@ func TestStructSlice(t *testing.T) {
 
 	cdc := amino.NewCodec()
 
-	bz, err := cdc.MarshalBinaryBare(f)
+	bz, err := cdc.MarshalBinary(f)
 	assert.NoError(t, err)
 	assert.Equal(t, "0A0608C80110CA010A0608CC0110CE01", fmt.Sprintf("%X", bz))
 	t.Log(bz)
 	var f2 Foos
-	cdc.UnmarshalBinaryBare(bz, &f2)
+	cdc.UnmarshalBinary(bz, &f2)
 	assert.Equal(t, f, f2)
 }
 
@@ -191,11 +191,11 @@ func TestStructPointerSlice1(t *testing.T) {
 		C: []*Foo{nil, nil, nil},
 		D: "j",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)
@@ -207,7 +207,7 @@ func TestStructPointerSlice1(t *testing.T) {
 		C: []*Foo{&Foo{}, &Foo{}, &Foo{}},
 		D: "j",
 	}
-	bz2, err := cdc.MarshalBinary(f3)
+	bz2, err := cdc.MarshalBinaryLengthPrefixed(f3)
 	assert.NoError(t, err)
 	assert.Equal(t, bz, bz2, "empty slices should be decoded to nil unless empty_elements")
 }
@@ -229,15 +229,15 @@ func TestStructPointerSlice2(t *testing.T) {
 		C: []*Foo{nil, nil, nil},
 		D: "j",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.Error(t, err, "nil elements of a slice/array not supported when empty_elements field tag set.")
 
 	f.C = []*Foo{&Foo{}, &Foo{}, &Foo{}}
-	bz, err = cdc.MarshalBinary(f)
+	bz, err = cdc.MarshalBinaryLengthPrefixed(f)
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/byteslice_test.go
+++ b/byteslice_test.go
@@ -13,14 +13,14 @@ func TestReadByteSliceEquality(t *testing.T) {
 
 	// Write a byteslice
 	var testBytes = []byte("ThisIsSomeTestArray")
-	encoded, err = cdc.MarshalBinary(testBytes)
+	encoded, err = cdc.MarshalBinaryLengthPrefixed(testBytes)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Read the byteslice, should return the same byteslice
 	var testBytes2 []byte
-	err = cdc.UnmarshalBinary(encoded, &testBytes2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(encoded, &testBytes2)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/byteslice_test.go
+++ b/byteslice_test.go
@@ -13,14 +13,14 @@ func TestReadByteSliceEquality(t *testing.T) {
 
 	// Write a byteslice
 	var testBytes = []byte("ThisIsSomeTestArray")
-	encoded, err = cdc.MarshalBinaryLengthPrefixed(testBytes)
+	encoded, err = cdc.MarshalBinary(testBytes)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Read the byteslice, should return the same byteslice
 	var testBytes2 []byte
-	err = cdc.UnmarshalBinaryLengthPrefixed(encoded, &testBytes2)
+	err = cdc.UnmarshalBinary(encoded, &testBytes2)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/byteslice_test.go
+++ b/byteslice_test.go
@@ -13,14 +13,14 @@ func TestReadByteSliceEquality(t *testing.T) {
 
 	// Write a byteslice
 	var testBytes = []byte("ThisIsSomeTestArray")
-	encoded, err = cdc.MarshalBinary(testBytes)
+	encoded, err = cdc.MarshalBinaryLengthPrefixed(testBytes)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Read the byteslice, should return the same byteslice
 	var testBytes2 []byte
-	err = cdc.UnmarshalBinary(encoded, &testBytes2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(encoded, &testBytes2)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -30,11 +30,11 @@ func TestMarshalUnmarshalBinaryPointer0(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(s) // no indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -44,11 +44,11 @@ func TestMarshalUnmarshalBinaryPointer1(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&s) // extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&s) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -59,11 +59,11 @@ func TestMarshalUnmarshalBinaryPointer2(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&ptr) // double extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // double extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -73,11 +73,11 @@ func TestMarshalUnmarshalBinaryPointer3(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(s) // no indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 }
@@ -87,11 +87,11 @@ func TestMarshalUnmarshalBinaryPointer4(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&ptr) // extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -30,11 +30,11 @@ func TestMarshalUnmarshalBinaryPointer0(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
+	b, err := cdc.MarshalBinary(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
+	err = cdc.UnmarshalBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -44,11 +44,11 @@ func TestMarshalUnmarshalBinaryPointer1(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryLengthPrefixed(&s) // extra indirection
+	b, err := cdc.MarshalBinary(&s) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
+	err = cdc.UnmarshalBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -59,11 +59,11 @@ func TestMarshalUnmarshalBinaryPointer2(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // double extra indirection
+	b, err := cdc.MarshalBinary(&ptr) // double extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
+	err = cdc.UnmarshalBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -73,11 +73,11 @@ func TestMarshalUnmarshalBinaryPointer3(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
+	b, err := cdc.MarshalBinary(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 }
@@ -87,11 +87,11 @@ func TestMarshalUnmarshalBinaryPointer4(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // extra indirection
+	b, err := cdc.MarshalBinary(&ptr) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -30,11 +30,11 @@ func TestMarshalUnmarshalBinaryPointer0(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(s) // no indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -44,11 +44,11 @@ func TestMarshalUnmarshalBinaryPointer1(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&s) // extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&s) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -59,11 +59,11 @@ func TestMarshalUnmarshalBinaryPointer2(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&ptr) // double extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // double extra indirection
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -73,11 +73,11 @@ func TestMarshalUnmarshalBinaryPointer3(t *testing.T) {
 
 	var s = newSimpleStruct()
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(s) // no indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(s) // no indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 }
@@ -87,11 +87,11 @@ func TestMarshalUnmarshalBinaryPointer4(t *testing.T) {
 	var s = newSimpleStruct()
 	var ptr = &s
 	cdc := amino.NewCodec()
-	b, err := cdc.MarshalBinary(&ptr) // extra indirection
+	b, err := cdc.MarshalBinaryLengthPrefixed(&ptr) // extra indirection
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 

--- a/example_test.go
+++ b/example_test.go
@@ -55,11 +55,11 @@ func Example() {
 
 	var bz []byte // the marshalled bytes.
 	var err error
-	bz, err = cdc.MarshalBinaryLengthPrefixed(msg)
+	bz, err = cdc.MarshalBinary(msg)
 	fmt.Printf("Encoded: %X (err: %v)\n", bz, err)
 
 	var msg2 Message
-	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &msg2)
+	err = cdc.UnmarshalBinary(bz, &msg2)
 	fmt.Printf("Decoded: %v (err: %v)\n", msg2, err)
 	var bm2 = msg2.(*bcMessage)
 	fmt.Printf("Decoded successfully: %v\n", *bm == *bm2)

--- a/example_test.go
+++ b/example_test.go
@@ -55,11 +55,11 @@ func Example() {
 
 	var bz []byte // the marshalled bytes.
 	var err error
-	bz, err = cdc.MarshalBinary(msg)
+	bz, err = cdc.MarshalBinaryLengthPrefixed(msg)
 	fmt.Printf("Encoded: %X (err: %v)\n", bz, err)
 
 	var msg2 Message
-	err = cdc.UnmarshalBinary(bz, &msg2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &msg2)
 	fmt.Printf("Decoded: %v (err: %v)\n", msg2, err)
 	var bm2 = msg2.(*bcMessage)
 	fmt.Printf("Decoded successfully: %v\n", *bm == *bm2)

--- a/example_test.go
+++ b/example_test.go
@@ -55,11 +55,11 @@ func Example() {
 
 	var bz []byte // the marshalled bytes.
 	var err error
-	bz, err = cdc.MarshalBinary(msg)
+	bz, err = cdc.MarshalBinaryLengthPrefixed(msg)
 	fmt.Printf("Encoded: %X (err: %v)\n", bz, err)
 
 	var msg2 Message
-	err = cdc.UnmarshalBinary(bz, &msg2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &msg2)
 	fmt.Printf("Decoded: %v (err: %v)\n", msg2, err)
 	var bm2 = msg2.(*bcMessage)
 	fmt.Printf("Decoded successfully: %v\n", *bm == *bm2)

--- a/json_test.go
+++ b/json_test.go
@@ -176,16 +176,16 @@ func TestUnmarshalMap(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a map...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinary(obj)
+		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a map...
@@ -211,16 +211,16 @@ func TestUnmarshalFunc(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a func...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinary(obj)
+		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a func...

--- a/json_test.go
+++ b/json_test.go
@@ -176,16 +176,16 @@ func TestUnmarshalMap(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a map...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinary(obj)
+		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a map...
@@ -211,16 +211,16 @@ func TestUnmarshalFunc(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a func...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinary(obj)
+		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a func...

--- a/json_test.go
+++ b/json_test.go
@@ -176,16 +176,16 @@ func TestUnmarshalMap(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a map...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
+		err := cdc.UnmarshalBinary(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
+		err := cdc.UnmarshalBinary(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
+		bz, err := cdc.MarshalBinary(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a map...
@@ -211,16 +211,16 @@ func TestUnmarshalFunc(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a func...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
+		err := cdc.UnmarshalBinary(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
+		err := cdc.UnmarshalBinary(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
 	assert.Panics(t, func() {
-		bz, err := cdc.MarshalBinaryLengthPrefixed(obj)
+		bz, err := cdc.MarshalBinary(obj)
 		assert.Fail(t, "should have paniced but got bz: %X err: %v", bz, err)
 	})
 	// JSON doesn't support decoding to a func...

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -83,7 +83,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 
 		switch codecType {
 		case "binary":
-			bz, err = cdc.MarshalBinaryBare(ptr)
+			bz, err = cdc.MarshalBinary(ptr)
 		case "json":
 			bz, err = cdc.MarshalJSON(ptr)
 		default:
@@ -95,7 +95,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 
 		switch codecType {
 		case "binary":
-			err = cdc.UnmarshalBinaryBare(bz, ptr2)
+			err = cdc.UnmarshalBinary(bz, ptr2)
 		case "json":
 			err = cdc.UnmarshalJSON(bz, ptr2)
 		default:
@@ -148,7 +148,7 @@ func TestCodecBinaryRegister1(t *testing.T) {
 	//cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 
-	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.NotNil(t, err, "unregistered interface")
 	assert.Empty(t, bz)
 }
@@ -158,7 +158,7 @@ func TestCodecBinaryRegister2(t *testing.T) {
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 
-	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -169,7 +169,7 @@ func TestCodecBinaryRegister3(t *testing.T) {
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 
-	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -182,7 +182,7 @@ func TestCodecBinaryRegister4(t *testing.T) {
 		AlwaysDisambiguate: true,
 	})
 
-	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x8, 0x0, 0x12, 0xb5, 0x86, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -193,7 +193,7 @@ func TestCodecBinaryRegister5(t *testing.T) {
 	//cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 
-	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.NotNil(t, err, "concrete type not registered")
 	assert.Empty(t, bz)
 }
@@ -215,14 +215,14 @@ func TestCodecBinaryRegister7(t *testing.T) {
 	cdc.RegisterConcrete((*tests.Concrete2)(nil), "Concrete2", nil)
 
 	{ // test tests.Concrete1, no conflict.
-		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
+		bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
 		assert.Nil(t, err, "correctly registered")
 		assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 			"disfix bytes did not match")
 	}
 
 	{ // test tests.Concrete2, no conflict
-		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete2{}})
+		bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete2{}})
 		assert.Nil(t, err, "correctly registered")
 		assert.Equal(t, []byte{0xa, 0x4, 0x6a, 0x9, 0xca, 0x1}, bz,
 			"disfix bytes did not match")
@@ -242,13 +242,13 @@ func TestCodecBinaryRegister8(t *testing.T) {
 	var c3 tests.Concrete3
 	copy(c3[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinaryBare(c3)
+	bz, err := cdc.MarshalBinary(c3)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
-	err = cdc.UnmarshalBinaryBare(bz, &i1)
+	err = cdc.UnmarshalBinary(bz, &i1)
 	assert.Nil(t, err)
 	assert.Equal(t, c3, i1)
 }
@@ -288,13 +288,13 @@ func TestCodecBinaryRegister9(t *testing.T) {
 	var c3 tests.Concrete3
 	copy(c3[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinaryBare(c3)
+	bz, err := cdc.MarshalBinary(c3)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
-	err = cdc.UnmarshalBinaryBare(bz, &i1)
+	err = cdc.UnmarshalBinary(bz, &i1)
 	assert.Nil(t, err)
 	assert.Equal(t, c3, i1)
 }
@@ -308,13 +308,13 @@ func TestCodecBinaryRegister10(t *testing.T) {
 	var c3a tests.Concrete3
 	copy(c3a[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinaryBare(c3a)
+	bz, err := cdc.MarshalBinary(c3a)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var c3b tests.Concrete3
-	err = cdc.UnmarshalBinaryBare(bz, &c3b)
+	err = cdc.UnmarshalBinary(bz, &c3b)
 	assert.Nil(t, err)
 	assert.Equal(t, c3a, c3b)
 }
@@ -325,11 +325,11 @@ func TestCodecBinaryStructFieldNilInterface(t *testing.T) {
 	cdc.RegisterConcrete((*tests.InterfaceFieldsStruct)(nil), "interfaceFields", nil)
 
 	i1 := &tests.InterfaceFieldsStruct{F1: new(tests.InterfaceFieldsStruct), F2: nil}
-	bz, err := cdc.MarshalBinary(i1)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(i1)
 	assert.Nil(t, err, "unexpected error")
 
 	i2 := new(tests.InterfaceFieldsStruct)
-	err = cdc.UnmarshalBinary(bz, i2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, i2)
 
 	assert.Nil(t, err, "unexpected error")
 	require.Equal(t, i1, i2, "i1 and i2 should be the same after decoding")

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -325,11 +325,11 @@ func TestCodecBinaryStructFieldNilInterface(t *testing.T) {
 	cdc.RegisterConcrete((*tests.InterfaceFieldsStruct)(nil), "interfaceFields", nil)
 
 	i1 := &tests.InterfaceFieldsStruct{F1: new(tests.InterfaceFieldsStruct), F2: nil}
-	bz, err := cdc.MarshalBinary(i1)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(i1)
 	assert.Nil(t, err, "unexpected error")
 
 	i2 := new(tests.InterfaceFieldsStruct)
-	err = cdc.UnmarshalBinary(bz, i2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, i2)
 
 	assert.Nil(t, err, "unexpected error")
 	require.Equal(t, i1, i2, "i1 and i2 should be the same after decoding")

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -83,7 +83,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 
 		switch codecType {
 		case "binary":
-			bz, err = cdc.MarshalBinary(ptr)
+			bz, err = cdc.MarshalBinaryBare(ptr)
 		case "json":
 			bz, err = cdc.MarshalJSON(ptr)
 		default:
@@ -95,7 +95,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 
 		switch codecType {
 		case "binary":
-			err = cdc.UnmarshalBinary(bz, ptr2)
+			err = cdc.UnmarshalBinaryBare(bz, ptr2)
 		case "json":
 			err = cdc.UnmarshalJSON(bz, ptr2)
 		default:
@@ -148,7 +148,7 @@ func TestCodecBinaryRegister1(t *testing.T) {
 	//cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 
-	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.NotNil(t, err, "unregistered interface")
 	assert.Empty(t, bz)
 }
@@ -158,7 +158,7 @@ func TestCodecBinaryRegister2(t *testing.T) {
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 
-	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -169,7 +169,7 @@ func TestCodecBinaryRegister3(t *testing.T) {
 	cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 
-	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -182,7 +182,7 @@ func TestCodecBinaryRegister4(t *testing.T) {
 		AlwaysDisambiguate: true,
 	})
 
-	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.Nil(t, err, "correctly registered")
 	assert.Equal(t, []byte{0xa, 0x8, 0x0, 0x12, 0xb5, 0x86, 0xe3, 0xda, 0xb8, 0x33}, bz,
 		"prefix bytes did not match")
@@ -193,7 +193,7 @@ func TestCodecBinaryRegister5(t *testing.T) {
 	//cdc.RegisterConcrete((*tests.Concrete1)(nil), "Concrete1", nil)
 	cdc.RegisterInterface((*tests.Interface1)(nil), nil)
 
-	bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+	bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.NotNil(t, err, "concrete type not registered")
 	assert.Empty(t, bz)
 }
@@ -215,14 +215,14 @@ func TestCodecBinaryRegister7(t *testing.T) {
 	cdc.RegisterConcrete((*tests.Concrete2)(nil), "Concrete2", nil)
 
 	{ // test tests.Concrete1, no conflict.
-		bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete1{}})
+		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete1{}})
 		assert.Nil(t, err, "correctly registered")
 		assert.Equal(t, []byte{0xa, 0x4, 0xe3, 0xda, 0xb8, 0x33}, bz,
 			"disfix bytes did not match")
 	}
 
 	{ // test tests.Concrete2, no conflict
-		bz, err := cdc.MarshalBinary(struct{ tests.Interface1 }{tests.Concrete2{}})
+		bz, err := cdc.MarshalBinaryBare(struct{ tests.Interface1 }{tests.Concrete2{}})
 		assert.Nil(t, err, "correctly registered")
 		assert.Equal(t, []byte{0xa, 0x4, 0x6a, 0x9, 0xca, 0x1}, bz,
 			"disfix bytes did not match")
@@ -242,13 +242,13 @@ func TestCodecBinaryRegister8(t *testing.T) {
 	var c3 tests.Concrete3
 	copy(c3[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinary(c3)
+	bz, err := cdc.MarshalBinaryBare(c3)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
-	err = cdc.UnmarshalBinary(bz, &i1)
+	err = cdc.UnmarshalBinaryBare(bz, &i1)
 	assert.Nil(t, err)
 	assert.Equal(t, c3, i1)
 }
@@ -288,13 +288,13 @@ func TestCodecBinaryRegister9(t *testing.T) {
 	var c3 tests.Concrete3
 	copy(c3[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinary(c3)
+	bz, err := cdc.MarshalBinaryBare(c3)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var i1 tests.Interface1
-	err = cdc.UnmarshalBinary(bz, &i1)
+	err = cdc.UnmarshalBinaryBare(bz, &i1)
 	assert.Nil(t, err)
 	assert.Equal(t, c3, i1)
 }
@@ -308,13 +308,13 @@ func TestCodecBinaryRegister10(t *testing.T) {
 	var c3a tests.Concrete3
 	copy(c3a[:], []byte("0123"))
 
-	bz, err := cdc.MarshalBinary(c3a)
+	bz, err := cdc.MarshalBinaryBare(c3a)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{0x53, 0x37, 0x21, 0x1, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"Concrete3 incorrectly serialized")
 
 	var c3b tests.Concrete3
-	err = cdc.UnmarshalBinary(bz, &c3b)
+	err = cdc.UnmarshalBinaryBare(bz, &c3b)
 	assert.Nil(t, err)
 	assert.Equal(t, c3a, c3b)
 }
@@ -325,11 +325,11 @@ func TestCodecBinaryStructFieldNilInterface(t *testing.T) {
 	cdc.RegisterConcrete((*tests.InterfaceFieldsStruct)(nil), "interfaceFields", nil)
 
 	i1 := &tests.InterfaceFieldsStruct{F1: new(tests.InterfaceFieldsStruct), F2: nil}
-	bz, err := cdc.MarshalBinaryLengthPrefixed(i1)
+	bz, err := cdc.MarshalBinary(i1)
 	assert.Nil(t, err, "unexpected error")
 
 	i2 := new(tests.InterfaceFieldsStruct)
-	err = cdc.UnmarshalBinaryLengthPrefixed(bz, i2)
+	err = cdc.UnmarshalBinary(bz, i2)
 
 	assert.Nil(t, err, "unexpected error")
 	require.Equal(t, i1, i2, "i1 and i2 should be the same after decoding")

--- a/repr_test.go
+++ b/repr_test.go
@@ -57,13 +57,13 @@ func TestMarshalAminoBinary(t *testing.T) {
 		c: []*Foo{nil, nil, nil},
 		D: "J",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.Nil(t, err)
 
 	t.Logf("bz %X", bz)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/repr_test.go
+++ b/repr_test.go
@@ -57,13 +57,13 @@ func TestMarshalAminoBinary(t *testing.T) {
 		c: []*Foo{nil, nil, nil},
 		D: "J",
 	}
-	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
+	bz, err := cdc.MarshalBinary(f)
 	assert.Nil(t, err)
 
 	t.Logf("bz %X", bz)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
+	err = cdc.UnmarshalBinary(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/repr_test.go
+++ b/repr_test.go
@@ -57,13 +57,13 @@ func TestMarshalAminoBinary(t *testing.T) {
 		c: []*Foo{nil, nil, nil},
 		D: "J",
 	}
-	bz, err := cdc.MarshalBinary(f)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(f)
 	assert.Nil(t, err)
 
 	t.Logf("bz %X", bz)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/tests/fuzz/binary/binary.go
+++ b/tests/fuzz/binary/binary.go
@@ -13,7 +13,7 @@ import (
 func Fuzz(data []byte) int {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinary(data, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixed(data, &cst)
 	if err != nil {
 		return 0
 	}

--- a/tests/fuzz/binary/binary.go
+++ b/tests/fuzz/binary/binary.go
@@ -13,7 +13,7 @@ import (
 func Fuzz(data []byte) int {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinary(data, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixedBinary(data, &cst)
 	if err != nil {
 		return 0
 	}

--- a/tests/fuzz/binary/binary.go
+++ b/tests/fuzz/binary/binary.go
@@ -13,7 +13,7 @@ import (
 func Fuzz(data []byte) int {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinaryLengthPrefixed(data, &cst)
+	err := cdc.UnmarshalBinary(data, &cst)
 	if err != nil {
 		return 0
 	}

--- a/tests/fuzz/binary/debug/main.go
+++ b/tests/fuzz/binary/debug/main.go
@@ -12,6 +12,6 @@ func main() {
 	bz := []byte("\a\x1a\x05\x1a\x01\x80\xf7\x00")
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinary(bz, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixed(bz, &cst)
 	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }

--- a/tests/fuzz/binary/debug/main.go
+++ b/tests/fuzz/binary/debug/main.go
@@ -12,6 +12,6 @@ func main() {
 	bz := []byte("\a\x1a\x05\x1a\x01\x80\xf7\x00")
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinary(bz, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &cst)
 	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }

--- a/tests/fuzz/binary/debug/main.go
+++ b/tests/fuzz/binary/debug/main.go
@@ -12,6 +12,6 @@ func main() {
 	bz := []byte("\a\x1a\x05\x1a\x01\x80\xf7\x00")
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinaryLengthPrefixed(bz, &cst)
+	err := cdc.UnmarshalBinary(bz, &cst)
 	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }

--- a/tests/fuzz/binary/init-corpus/main.go
+++ b/tests/fuzz/binary/init-corpus/main.go
@@ -136,7 +136,7 @@ func main() {
 	cdc.RegisterConcrete(&tests.SlicesStruct{}, "com.tendermint/slices_st", nil)
 
 	for i, seed := range seeds {
-		blob, err := cdc.MarshalBinaryLengthPrefixed(seed)
+		blob, err := cdc.MarshalBinary(seed)
 		if err != nil {
 			log.Fatalf("Failed to marshalBinary on seed: %d", i)
 		}

--- a/tests/fuzz/binary/init-corpus/main.go
+++ b/tests/fuzz/binary/init-corpus/main.go
@@ -136,7 +136,7 @@ func main() {
 	cdc.RegisterConcrete(&tests.SlicesStruct{}, "com.tendermint/slices_st", nil)
 
 	for i, seed := range seeds {
-		blob, err := cdc.MarshalBinary(seed)
+		blob, err := cdc.MarshalBinaryLengthPrefixed(seed)
 		if err != nil {
 			log.Fatalf("Failed to marshalBinary on seed: %d", i)
 		}

--- a/tests/proto3/proto3_compat_test.go
+++ b/tests/proto3/proto3_compat_test.go
@@ -21,7 +21,7 @@ func TestFixed32Roundtrip(t *testing.T) {
 	type testi32 struct {
 		Int32 int32 `binary:"fixed32"`
 	}
-	ab, err := cdc.MarshalBinary(testi32{Int32: 150})
+	ab, err := cdc.MarshalBinaryBare(testi32{Int32: 150})
 	assert.NoError(t, err, "unexpected error")
 
 	pb, err := proto.Marshal(&p3.TestInt32Fixed{Fixed32: 150})
@@ -35,7 +35,7 @@ func TestFixed32Roundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &pt)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &att)
+	err = cdc.UnmarshalBinaryBare(pb, &att)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.Equal(t, uint32(att.Int32), pt.Foo)
@@ -48,7 +48,7 @@ func TestVarintZigzagRoundtrip(t *testing.T) {
 		Int32 int `binary:"varint"`
 	}
 	varint := testInt32Varint{Int32: 6000000}
-	ab, err := cdc.MarshalBinary(varint)
+	ab, err := cdc.MarshalBinaryBare(varint)
 	assert.NoError(t, err, "unexpected error")
 	pb, err := proto.Marshal(&p3.TestInt32Varint{Int32: 6000000})
 	assert.NoError(t, err, "unexpected error")
@@ -59,7 +59,7 @@ func TestVarintZigzagRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, varint.Int32, amToP3.Int32)
@@ -71,7 +71,7 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 		Foo int32 `binary:"fixed32"`
 		Bar int   `binary:"varint"`
 	}
-	ab, err := cdc.MarshalBinary(test32{Foo: 150, Bar: 150})
+	ab, err := cdc.MarshalBinaryBare(test32{Foo: 150, Bar: 150})
 	assert.NoError(t, err, "unexpected error")
 	pb, err := proto.Marshal(&p3.Test32{Foo: 150, Bar: 150})
 	assert.NoError(t, err, "unexpected error")
@@ -82,13 +82,13 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm.Foo, amToP3.Foo)
 
 	// same as above but with skipped fields:
-	ab, err = cdc.MarshalBinary(test32{})
+	ab, err = cdc.MarshalBinaryBare(test32{})
 	assert.NoError(t, err, "unexpected error")
 	pb, err = proto.Marshal(&p3.Test32{})
 	assert.NoError(t, err, "unexpected error")
@@ -97,7 +97,7 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm.Foo, amToP3.Foo)
@@ -113,7 +113,7 @@ func TestFixedU64Roundtrip(t *testing.T) {
 
 	pvint64 := p3.TestFixedInt64{Int64: 150}
 	avint64 := testFixed64Uint{Int64: 150}
-	ab, err := cdc.MarshalBinary(avint64)
+	ab, err := cdc.MarshalBinaryBare(avint64)
 	assert.NoError(t, err, "unexpected error")
 
 	pb, err := proto.Marshal(&pvint64)
@@ -126,7 +126,7 @@ func TestFixedU64Roundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)
@@ -136,7 +136,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	cdc := amino.NewCodec()
 	s := p3.SomeStruct{}
 
-	ab, err := cdc.MarshalBinary(s)
+	ab, err := cdc.MarshalBinaryBare(s)
 	assert.NoError(t, err)
 
 	pb, err := proto.Marshal(&s)
@@ -150,7 +150,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)
@@ -158,7 +158,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 
 	s2 := p3.SomeStruct{Emb: &p3.EmbeddedStruct{}}
 
-	ab, err = cdc.MarshalBinary(s2)
+	ab, err = cdc.MarshalBinaryBare(s2)
 	assert.NoError(t, err)
 
 	pb, err = proto.Marshal(&s2)
@@ -168,7 +168,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinary(pb, &p3ToAm)
+	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)

--- a/tests/proto3/proto3_compat_test.go
+++ b/tests/proto3/proto3_compat_test.go
@@ -21,7 +21,7 @@ func TestFixed32Roundtrip(t *testing.T) {
 	type testi32 struct {
 		Int32 int32 `binary:"fixed32"`
 	}
-	ab, err := cdc.MarshalBinaryBare(testi32{Int32: 150})
+	ab, err := cdc.MarshalBinary(testi32{Int32: 150})
 	assert.NoError(t, err, "unexpected error")
 
 	pb, err := proto.Marshal(&p3.TestInt32Fixed{Fixed32: 150})
@@ -35,7 +35,7 @@ func TestFixed32Roundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &pt)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &att)
+	err = cdc.UnmarshalBinary(pb, &att)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.Equal(t, uint32(att.Int32), pt.Foo)
@@ -48,7 +48,7 @@ func TestVarintZigzagRoundtrip(t *testing.T) {
 		Int32 int `binary:"varint"`
 	}
 	varint := testInt32Varint{Int32: 6000000}
-	ab, err := cdc.MarshalBinaryBare(varint)
+	ab, err := cdc.MarshalBinary(varint)
 	assert.NoError(t, err, "unexpected error")
 	pb, err := proto.Marshal(&p3.TestInt32Varint{Int32: 6000000})
 	assert.NoError(t, err, "unexpected error")
@@ -59,7 +59,7 @@ func TestVarintZigzagRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, varint.Int32, amToP3.Int32)
@@ -71,7 +71,7 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 		Foo int32 `binary:"fixed32"`
 		Bar int   `binary:"varint"`
 	}
-	ab, err := cdc.MarshalBinaryBare(test32{Foo: 150, Bar: 150})
+	ab, err := cdc.MarshalBinary(test32{Foo: 150, Bar: 150})
 	assert.NoError(t, err, "unexpected error")
 	pb, err := proto.Marshal(&p3.Test32{Foo: 150, Bar: 150})
 	assert.NoError(t, err, "unexpected error")
@@ -82,13 +82,13 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm.Foo, amToP3.Foo)
 
 	// same as above but with skipped fields:
-	ab, err = cdc.MarshalBinaryBare(test32{})
+	ab, err = cdc.MarshalBinary(test32{})
 	assert.NoError(t, err, "unexpected error")
 	pb, err = proto.Marshal(&p3.Test32{})
 	assert.NoError(t, err, "unexpected error")
@@ -97,7 +97,7 @@ func TestMixedFixedVarintRoudtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm.Foo, amToP3.Foo)
@@ -113,7 +113,7 @@ func TestFixedU64Roundtrip(t *testing.T) {
 
 	pvint64 := p3.TestFixedInt64{Int64: 150}
 	avint64 := testFixed64Uint{Int64: 150}
-	ab, err := cdc.MarshalBinaryBare(avint64)
+	ab, err := cdc.MarshalBinary(avint64)
 	assert.NoError(t, err, "unexpected error")
 
 	pb, err := proto.Marshal(&pvint64)
@@ -126,7 +126,7 @@ func TestFixedU64Roundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)
@@ -136,7 +136,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	cdc := amino.NewCodec()
 	s := p3.SomeStruct{}
 
-	ab, err := cdc.MarshalBinaryBare(s)
+	ab, err := cdc.MarshalBinary(s)
 	assert.NoError(t, err)
 
 	pb, err := proto.Marshal(&s)
@@ -150,7 +150,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)
@@ -158,7 +158,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 
 	s2 := p3.SomeStruct{Emb: &p3.EmbeddedStruct{}}
 
-	ab, err = cdc.MarshalBinaryBare(s2)
+	ab, err = cdc.MarshalBinary(s2)
 	assert.NoError(t, err)
 
 	pb, err = proto.Marshal(&s2)
@@ -168,7 +168,7 @@ func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	err = proto.Unmarshal(ab, &amToP3)
 	assert.NoError(t, err, "unexpected error")
 
-	err = cdc.UnmarshalBinaryBare(pb, &p3ToAm)
+	err = cdc.UnmarshalBinary(pb, &p3ToAm)
 	assert.NoError(t, err, "unexpected error")
 
 	assert.EqualValues(t, p3ToAm, amToP3)

--- a/time2_test.go
+++ b/time2_test.go
@@ -16,19 +16,19 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	tm, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err := cdc.MarshalBinary(testTime{Time: tm})
+	b, err := cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm})
 	assert.NoError(t, err)
 	var ti testTime
-	err = cdc.UnmarshalBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm}, ti)
 
 	tm2, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:01.978131102 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err = cdc.MarshalBinary(testTime{Time: tm2})
+	b, err = cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm2})
 	assert.NoError(t, err)
-	err = cdc.UnmarshalBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
 
@@ -43,11 +43,11 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	st := tArr{
 		TimeAr: [4]time.Time{t1, t2, t3, t4},
 	}
-	b, err = cdc.MarshalBinary(st)
+	b, err = cdc.MarshalBinaryLengthPrefixed(st)
 	assert.NoError(t, err)
 
 	var tStruct tArr
-	err = cdc.UnmarshalBinary(b, &tStruct)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &tStruct)
 	assert.NoError(t, err)
 	assert.Equal(t, st, tStruct)
 }

--- a/time2_test.go
+++ b/time2_test.go
@@ -16,19 +16,19 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	tm, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err := cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm})
+	b, err := cdc.MarshalBinary(testTime{Time: tm})
 	assert.NoError(t, err)
 	var ti testTime
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
+	err = cdc.UnmarshalBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm}, ti)
 
 	tm2, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:01.978131102 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err = cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm2})
+	b, err = cdc.MarshalBinary(testTime{Time: tm2})
 	assert.NoError(t, err)
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
+	err = cdc.UnmarshalBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
 
@@ -43,11 +43,11 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	st := tArr{
 		TimeAr: [4]time.Time{t1, t2, t3, t4},
 	}
-	b, err = cdc.MarshalBinaryLengthPrefixed(st)
+	b, err = cdc.MarshalBinary(st)
 	assert.NoError(t, err)
 
 	var tStruct tArr
-	err = cdc.UnmarshalBinaryLengthPrefixed(b, &tStruct)
+	err = cdc.UnmarshalBinary(b, &tStruct)
 	assert.NoError(t, err)
 	assert.Equal(t, st, tStruct)
 }

--- a/time2_test.go
+++ b/time2_test.go
@@ -16,19 +16,19 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	tm, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:00 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err := cdc.MarshalBinary(testTime{Time: tm})
+	b, err := cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm})
 	assert.NoError(t, err)
 	var ti testTime
-	err = cdc.UnmarshalBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm}, ti)
 
 	tm2, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", "1970-01-01 00:00:01.978131102 +0000 UTC")
 	assert.NoError(t, err)
 
-	b, err = cdc.MarshalBinary(testTime{Time: tm2})
+	b, err = cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm2})
 	assert.NoError(t, err)
-	err = cdc.UnmarshalBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
 
@@ -43,11 +43,11 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	st := tArr{
 		TimeAr: [4]time.Time{t1, t2, t3, t4},
 	}
-	b, err = cdc.MarshalBinary(st)
+	b, err = cdc.MarshalBinaryLengthPrefixed(st)
 	assert.NoError(t, err)
 
 	var tStruct tArr
-	err = cdc.UnmarshalBinary(b, &tStruct)
+	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &tStruct)
 	assert.NoError(t, err)
 	assert.Equal(t, st, tStruct)
 }


### PR DESCRIPTION
resolves #219 

~~as per discussion with @jaekwon I've added back the WIP in the title:~~

> it seems like we want to migrate in 2 steps, marshalbinary -> marshalbinarylengthprefixed first, then marshalbinarybare -> marshalbinary … cuz otherwise during migration we can miss switching marshalbinary -> marshalbinarybare and cause nasty bugs.
or we can just keep marshalbinarybare and rename marshalbinary -> marshalbinarylengthprefixed only.

I think the 2 steps approach works fine; keeping marshalbinarybare is simpler but less explicit (which the default is).

Currently, this PR only does the marshalbinary -> marshalbinarylengthprefixed step as explained above. 