### PR TITLE
No longer allocate space for uvarint size

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -83,6 +83,9 @@ func EncodeUvarint(w io.Writer, u uint64) (err error) {
 }
 
 func UvarintSize(u uint64) int {
+	if u == 0 {
+		return 1
+	}
 	return (bits.Len64(u) + 6) / 7
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+	"math/bits"
 	"time"
 )
 
@@ -82,9 +83,7 @@ func EncodeUvarint(w io.Writer, u uint64) (err error) {
 }
 
 func UvarintSize(u uint64) int {
-	var buf [10]byte
-	n := binary.PutUvarint(buf[:], u)
-	return n
+	return (bits.Len64(u) + 6) / 7
 }
 
 //----------------------------------------

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -13,37 +13,42 @@ func TestUvarintSize(t *testing.T) {
 		want int
 	}{
 		{
-			"1 bit",
-			1,
+			"0 bit",
+			0,
 			1,
 		},
 		{
-			"6 bit",
+			"1 bit",
+			1 << 0,
+			1,
+		},
+		{
+			"6 bits",
 			1 << 5,
 			1,
 		},
 		{
-			"7 bit",
+			"7 bits",
 			1 << 6,
 			1,
 		},
 		{
-			"8 bit",
+			"8 bits",
 			1 << 7,
 			2,
 		},
 		{
-			"62 bit",
+			"62 bits",
 			1 << 61,
 			9,
 		},
 		{
-			"63 bit",
+			"63 bits",
 			1 << 62,
 			9,
 		},
 		{
-			"64 bit",
+			"64 bits",
 			1 << 63,
 			10,
 		},

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,56 @@
+package amino
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUvarintSize(t *testing.T) {
+	tests := []struct {
+		name string
+		u    uint64
+		want int
+	}{
+		{
+			"1 bit",
+			1,
+			1,
+		},
+		{
+			"6 bit",
+			1 << 5,
+			1,
+		},
+		{
+			"7 bit",
+			1 << 6,
+			1,
+		},
+		{
+			"8 bit",
+			1 << 7,
+			2,
+		},
+		{
+			"62 bit",
+			1 << 61,
+			9,
+		},
+		{
+			"63 bit",
+			1 << 62,
+			9,
+		},
+		{
+			"64 bit",
+			1 << 63,
+			10,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, UvarintSize(tt.u), "failed on tc %d", i)
+		})
+	}
+}


### PR DESCRIPTION
In an area within the mempool, we ended not going with amino's implementation to due to allocation on every call. Its an easy fix, and I've added test cases to prove correctness.