### PR TITLE
Remove defers from getTypeInfo functions

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -358,6 +358,9 @@ func (cdc *Codec) setTypeInfo_nolock(info *TypeInfo) {
 }
 
 func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error) {
+	// We do not use defer cdc.mtx.Unlock() here due to performance overhead of
+	// defer in go1.11 (and prior versions). Ensure new code paths unlock the
+	// mutex.
 	cdc.mtx.Lock() // requires wlock because we might set.
 
 	// Dereference pointer type.
@@ -383,6 +386,9 @@ func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error)
 // iinfo: TypeInfo for the interface for which we must decode a
 // concrete type with prefix bytes pb.
 func (cdc *Codec) getTypeInfoFromPrefix_rlock(iinfo *TypeInfo, pb PrefixBytes) (info *TypeInfo, err error) {
+	// We do not use defer cdc.mtx.Unlock() here due to performance overhead of
+	// defer in go1.11 (and prior versions). Ensure new code paths unlock the
+	// mutex.
 	cdc.mtx.RLock()
 
 	infos, ok := iinfo.Implementers[pb]
@@ -402,6 +408,9 @@ func (cdc *Codec) getTypeInfoFromPrefix_rlock(iinfo *TypeInfo, pb PrefixBytes) (
 }
 
 func (cdc *Codec) getTypeInfoFromDisfix_rlock(df DisfixBytes) (info *TypeInfo, err error) {
+	// We do not use defer cdc.mtx.Unlock() here due to performance overhead of
+	// defer in go1.11 (and prior versions). Ensure new code paths unlock the
+	// mutex.
 	cdc.mtx.RLock()
 
 	info, ok := cdc.disfixToTypeInfo[df]
@@ -415,6 +424,9 @@ func (cdc *Codec) getTypeInfoFromDisfix_rlock(df DisfixBytes) (info *TypeInfo, e
 }
 
 func (cdc *Codec) getTypeInfoFromName_rlock(name string) (info *TypeInfo, err error) {
+	// We do not use defer cdc.mtx.Unlock() here due to performance overhead of
+	// defer in go1.11 (and prior versions). Ensure new code paths unlock the
+	// mutex.
 	cdc.mtx.RLock()
 
 	info, ok := cdc.nameToTypeInfo[name]

--- a/codec.go
+++ b/codec.go
@@ -359,7 +359,6 @@ func (cdc *Codec) setTypeInfo_nolock(info *TypeInfo) {
 
 func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error) {
 	cdc.mtx.Lock() // requires wlock because we might set.
-	defer cdc.mtx.Unlock()
 
 	// Dereference pointer type.
 	for rt.Kind() == reflect.Ptr {
@@ -370,12 +369,14 @@ func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error)
 	if !ok {
 		if rt.Kind() == reflect.Interface {
 			err = fmt.Errorf("Unregistered interface %v", rt)
+			cdc.mtx.Unlock()
 			return
 		}
 
 		info = cdc.newTypeInfoUnregistered(rt)
 		cdc.setTypeInfo_nolock(info)
 	}
+	cdc.mtx.Unlock()
 	return info, nil
 }
 
@@ -383,42 +384,46 @@ func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error)
 // concrete type with prefix bytes pb.
 func (cdc *Codec) getTypeInfoFromPrefix_rlock(iinfo *TypeInfo, pb PrefixBytes) (info *TypeInfo, err error) {
 	cdc.mtx.RLock()
-	defer cdc.mtx.RUnlock()
 
 	infos, ok := iinfo.Implementers[pb]
 	if !ok {
 		err = fmt.Errorf("unrecognized prefix bytes %X", pb)
+		cdc.mtx.RUnlock()
 		return
 	}
 	if len(infos) > 1 {
 		err = fmt.Errorf("conflicting concrete types registered for %X: e.g. %v and %v", pb, infos[0].Type, infos[1].Type)
+		cdc.mtx.RUnlock()
 		return
 	}
 	info = infos[0]
+	cdc.mtx.RUnlock()
 	return
 }
 
 func (cdc *Codec) getTypeInfoFromDisfix_rlock(df DisfixBytes) (info *TypeInfo, err error) {
 	cdc.mtx.RLock()
-	defer cdc.mtx.RUnlock()
 
 	info, ok := cdc.disfixToTypeInfo[df]
 	if !ok {
 		err = fmt.Errorf("unrecognized disambiguation+prefix bytes %X", df)
+		cdc.mtx.RUnlock()
 		return
 	}
+	cdc.mtx.RUnlock()
 	return
 }
 
 func (cdc *Codec) getTypeInfoFromName_rlock(name string) (info *TypeInfo, err error) {
 	cdc.mtx.RLock()
-	defer cdc.mtx.RUnlock()
 
 	info, ok := cdc.nameToTypeInfo[name]
 	if !ok {
 		err = fmt.Errorf("unrecognized concrete type name %s", name)
+		cdc.mtx.RUnlock()
 		return
 	}
+	cdc.mtx.RUnlock()
 	return
 }
 


### PR DESCRIPTION
These defers were taking up around .5% of the gaia state machines time,
due to their usage within MarshalJSON and UnmarshalBinaryBare. (exact percentage is a bit unclear)

There is no safety concern for removing these defers, as none of
the methods within the functions should panic.