### PR TITLE
Fix renaming of UnmarshalBinary

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -53,7 +53,7 @@ func MustMarshalBinaryBare(o interface{}) []byte {
 }
 
 func UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) error {
-	return gcdc.UnmarshalBinaryLengthPrefixedBinary(bz, ptr)
+	return gcdc.UnmarshalBinaryLengthPrefixed(bz, ptr)
 }
 
 func UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface{}, maxSize int64) (n int64, err error) {
@@ -228,11 +228,11 @@ func (cdc *Codec) MustMarshalBinaryBare(o interface{}) []byte {
 }
 
 // Like UnmarshalBinaryBare, but will first decode the byte-length prefix.
-// UnmarshalBinaryLengthPrefixedBinary will panic if ptr is a nil-pointer.
+// UnmarshalBinaryLengthPrefixed will panic if ptr is a nil-pointer.
 // Returns an error if not all of bz is consumed.
-func (cdc *Codec) UnmarshalBinaryLengthPrefixedBinary(bz []byte, ptr interface{}) error {
+func (cdc *Codec) UnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) error {
 	if len(bz) == 0 {
-		return errors.New("UnmarshalBinaryLengthPrefixedBinary cannot decode empty bytes")
+		return errors.New("UnmarshalBinaryLengthPrefixed cannot decode empty bytes")
 	}
 
 	// Read byte-length prefix.
@@ -241,10 +241,10 @@ func (cdc *Codec) UnmarshalBinaryLengthPrefixedBinary(bz []byte, ptr interface{}
 		return fmt.Errorf("Error reading msg byte-length prefix: got code %v", n)
 	}
 	if u64 > uint64(len(bz)-n) {
-		return fmt.Errorf("Not enough bytes to read in UnmarshalBinaryLengthPrefixedBinary, want %v more bytes but only have %v",
+		return fmt.Errorf("Not enough bytes to read in UnmarshalBinaryLengthPrefixed, want %v more bytes but only have %v",
 			u64, len(bz)-n)
 	} else if u64 < uint64(len(bz)-n) {
-		return fmt.Errorf("Bytes left over in UnmarshalBinaryLengthPrefixedBinary, should read %v more bytes but have %v",
+		return fmt.Errorf("Bytes left over in UnmarshalBinaryLengthPrefixed, should read %v more bytes but have %v",
 			u64, len(bz)-n)
 	}
 	bz = bz[n:]
@@ -311,7 +311,7 @@ func (cdc *Codec) UnmarshalBinaryLengthPrefixedReader(r io.Reader, ptr interface
 
 // Panics if error.
 func (cdc *Codec) MustUnmarshalBinaryLengthPrefixed(bz []byte, ptr interface{}) {
-	err := cdc.UnmarshalBinaryLengthPrefixedBinary(bz, ptr)
+	err := cdc.UnmarshalBinaryLengthPrefixed(bz, ptr)
 	if err != nil {
 		panic(err)
 	}

--- a/amino_test.go
+++ b/amino_test.go
@@ -29,7 +29,7 @@ func TestMarshalBinary(t *testing.T) {
 	t.Logf("MarshalBinaryLengthPrefixed(s) -> %X", b)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2)
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -195,7 +195,7 @@ func TestStructPointerSlice1(t *testing.T) {
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)
@@ -237,7 +237,7 @@ func TestStructPointerSlice2(t *testing.T) {
 	assert.NoError(t, err)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/byteslice_test.go
+++ b/byteslice_test.go
@@ -20,7 +20,7 @@ func TestReadByteSliceEquality(t *testing.T) {
 
 	// Read the byteslice, should return the same byteslice
 	var testBytes2 []byte
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(encoded, &testBytes2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(encoded, &testBytes2)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -34,7 +34,7 @@ func TestMarshalUnmarshalBinaryPointer0(t *testing.T) {
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -48,7 +48,7 @@ func TestMarshalUnmarshalBinaryPointer1(t *testing.T) {
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -63,7 +63,7 @@ func TestMarshalUnmarshalBinaryPointer2(t *testing.T) {
 	assert.Nil(t, err)
 
 	var s2 SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // no indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // no indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, s2)
 
@@ -77,7 +77,7 @@ func TestMarshalUnmarshalBinaryPointer3(t *testing.T) {
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 }
@@ -91,7 +91,7 @@ func TestMarshalUnmarshalBinaryPointer4(t *testing.T) {
 	assert.Nil(t, err)
 
 	var s2 *SimpleStruct
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &s2) // extra indirection
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &s2) // extra indirection
 	assert.Nil(t, err)
 	assert.Equal(t, s, *s2)
 

--- a/example_test.go
+++ b/example_test.go
@@ -59,7 +59,7 @@ func Example() {
 	fmt.Printf("Encoded: %X (err: %v)\n", bz, err)
 
 	var msg2 Message
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &msg2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &msg2)
 	fmt.Printf("Decoded: %v (err: %v)\n", msg2, err)
 	var bm2 = msg2.(*bcMessage)
 	fmt.Printf("Decoded successfully: %v\n", *bm == *bm2)

--- a/json_test.go
+++ b/json_test.go
@@ -178,11 +178,11 @@ func TestUnmarshalMap(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a map...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.
@@ -213,11 +213,11 @@ func TestUnmarshalFunc(t *testing.T) {
 	cdc := amino.NewCodec()
 	// Binary doesn't support decoding to a func...
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, &obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, &obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	assert.Panics(t, func() {
-		err := cdc.UnmarshalBinaryLengthPrefixedBinary(binBytes, obj)
+		err := cdc.UnmarshalBinaryLengthPrefixed(binBytes, obj)
 		assert.Fail(t, "should have paniced but got err: %v", err)
 	})
 	// ... nor encoding it.

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -329,7 +329,7 @@ func TestCodecBinaryStructFieldNilInterface(t *testing.T) {
 	assert.Nil(t, err, "unexpected error")
 
 	i2 := new(tests.InterfaceFieldsStruct)
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, i2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, i2)
 
 	assert.Nil(t, err, "unexpected error")
 	require.Equal(t, i1, i2, "i1 and i2 should be the same after decoding")

--- a/repr_test.go
+++ b/repr_test.go
@@ -63,7 +63,7 @@ func TestMarshalAminoBinary(t *testing.T) {
 	t.Logf("bz %X", bz)
 
 	var f2 Foo
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &f2)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &f2)
 	assert.Nil(t, err)
 
 	assert.Equal(t, f, f2)

--- a/tests/fuzz/binary/binary.go
+++ b/tests/fuzz/binary/binary.go
@@ -13,7 +13,7 @@ import (
 func Fuzz(data []byte) int {
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinaryLengthPrefixedBinary(data, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixed(data, &cst)
 	if err != nil {
 		return 0
 	}

--- a/tests/fuzz/binary/debug/main.go
+++ b/tests/fuzz/binary/debug/main.go
@@ -12,6 +12,6 @@ func main() {
 	bz := []byte("\a\x1a\x05\x1a\x01\x80\xf7\x00")
 	cdc := amino.NewCodec()
 	cst := tests.ComplexSt{}
-	err := cdc.UnmarshalBinaryLengthPrefixedBinary(bz, &cst)
+	err := cdc.UnmarshalBinaryLengthPrefixed(bz, &cst)
 	fmt.Printf("Expected a panic but did not. (err: %v)", err)
 }

--- a/time2_test.go
+++ b/time2_test.go
@@ -24,7 +24,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	b, err := cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm})
 	assert.NoError(t, err)
 	var ti testTime
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm}, ti)
 
@@ -33,7 +33,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 
 	b, err = cdc.MarshalBinaryLengthPrefixed(testTime{Time: tm2})
 	assert.NoError(t, err)
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &ti)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &ti)
 	assert.NoError(t, err)
 	assert.Equal(t, testTime{Time: tm2}, ti)
 
@@ -52,7 +52,7 @@ func TestDecodeSkippedFieldsInTime(t *testing.T) {
 	assert.NoError(t, err)
 
 	var tStruct tArr
-	err = cdc.UnmarshalBinaryLengthPrefixedBinary(b, &tStruct)
+	err = cdc.UnmarshalBinaryLengthPrefixed(b, &tStruct)
 	assert.NoError(t, err)
 	assert.Equal(t, st, tStruct)
 }


### PR DESCRIPTION
Hotfix: `UnmarshalBinaryLengthPrefixedBinary` should be `UnmarshalBinaryLengthPrefixed`
