### PR TITLE
Make amino build on 32bit architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.14.1 (November 6, 2018)
+
+IMPROVEMENTS:
+ - go-amino compiles again on 32-bit platforms ([#242])
+ 
+[#242]: https://github.com/tendermint/go-amino/pull/242
+
 ## 0.14.0 (October 26, 2018)
 
 BREAKING CHANGE:

--- a/encoder.go
+++ b/encoder.go
@@ -119,7 +119,7 @@ const (
 	// seconds of 01-01-0001
 	minSeconds int64 = -62135596800
 	// seconds of 10000-01-01
-	maxSeconds = int64(253402300800)
+	maxSeconds int64 = 253402300800
 
 	// nanos have to be in interval: [0, 999999999]
 	maxNanos = 999999999

--- a/encoder.go
+++ b/encoder.go
@@ -117,7 +117,7 @@ func EncodeFloat64(w io.Writer, f float64) (err error) {
 
 const (
 	// seconds of 01-01-0001
-	minSeconds = int64(-62135596800)
+	minSeconds int64 = -62135596800
 	// seconds of 10000-01-01
 	maxSeconds = int64(253402300800)
 

--- a/encoder.go
+++ b/encoder.go
@@ -117,9 +117,9 @@ func EncodeFloat64(w io.Writer, f float64) (err error) {
 
 const (
 	// seconds of 01-01-0001
-	minSeconds = -62135596800
+	minSeconds = int64(-62135596800)
 	// seconds of 10000-01-01
-	maxSeconds = 253402300800
+	maxSeconds = int64(253402300800)
 
 	// nanos have to be in interval: [0, 999999999]
 	maxNanos = 999999999
@@ -137,9 +137,7 @@ func (e InvalidTimeErr) Error() string {
 // Milliseconds are used to ease compatibility with Javascript,
 // which does not support finer resolution.
 func EncodeTime(w io.Writer, t time.Time) (err error) {
-	var s = t.Unix()
-	var ns = int32(t.Nanosecond()) // this int64 -> int32 is safe.
-
+	s := t.Unix()
 	// TODO: We are hand-encoding a struct until MarshalAmino/UnmarshalAmino is supported.
 	// skip if default/zero value:
 	if s != 0 {
@@ -156,9 +154,10 @@ func EncodeTime(w io.Writer, t time.Time) (err error) {
 			return
 		}
 	}
+	ns := int32(t.Nanosecond()) // this int64 -> int32 cast is safe (nanos are in [0, 999999999])
 	// skip if default/zero value:
 	if ns != 0 {
-		// do not encode if not in interval [0, 999999999]
+		// do not encode if nanos exceed allowed interval
 		if ns < 0 || ns > maxNanos {
 			// we could as well panic here:
 			// time.Time.Nanosecond() guarantees nanos to be in [0, 999,999,999]

--- a/tests/fuzz/binary/init-corpus/main.go
+++ b/tests/fuzz/binary/init-corpus/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -48,7 +49,7 @@ func main() {
 		Int32Ar:   [4]int32{0x7FFFFFFF, 0x6FFFFFFF, 0x5FFFFFFF, 0x77777777},
 		Int64Ar:   [4]int64{0x7FFFFFFFFFFFF, 0x6FFFFFFFFFFFF, 0x5FFFFFFFFFFFF, 0x80808000FFFFF},
 		VarintAr:  [4]int64{0x7FFFFFFFFFFFF, 0x6FFFFFFFFFFFF, 0x5FFFFFFFFFFFF, 0x80808000FFFFF},
-		IntAr:     [4]int{0x7FFFFFFF, 0x6FFFFFFF, 0x5FFFFFFF, 0x80808000},
+		IntAr:     [4]int{0x7FFFFFFF, 0x6FFFFFFF, 0x5FFFFFFF, math.MaxInt32},
 		ByteAr:    [4]byte{0xDE, 0xAD, 0xBE, 0xEF},
 		Uint8Ar:   [4]uint8{0xFF, 0xFF, 0x00, 0x88},
 		Uint16Ar:  [4]uint16{0xFFFF, 0xFFFF, 0xFF00, 0x8800},
@@ -66,7 +67,7 @@ func main() {
 		Int32Sl:   []int32{0x6FFFFFFF, 0x5FFFFFFF, 0x7FFFFFFF, 0x7F000000},
 		Int64Sl:   []int64{0x6FFFFFFFFFFFF, 0x5FFFFFFFFFFFF, 0x7FFFFFFFFFFFF, 0x80808000FFFFF},
 		VarintSl:  []int64{0x5FFFFFFFFFFFF, 0x7FFFFFFFFFFFF, 0x6FFFFFFFFFFFF, 0x80808000FFFFF},
-		IntSl:     []int{0x6FFFFFFF, 0x7FFFFFFF, 0x80808000, 0x5FFFFFFF},
+		IntSl:     []int{0x6FFFFFFF, 0x7FFFFFFF,  math.MaxInt32, 0x5FFFFFFF},
 		ByteSl:    []byte{0xAD, 0xBE, 0xDE, 0xEF},
 		Uint8Sl:   []uint8{0xFF, 0x00, 0x88, 0xFF},
 		Uint16Sl:  []uint16{0xFFFF, 0xFFFF, 0xFF00, 0x8800},


### PR DESCRIPTION
Some constants in encoder.go are interpreted as `int` by default and they overflow ints on 32bit machines: [encoder.go](https://github.com/tendermint/go-amino/blob/6dcc6ddc143e116455c94b25c1004c99e0d0ca12/encoder.go#L118-L122)
Similarly some values that seed the fuzzer: [here](https://github.com/tendermint/go-amino/blob/6dcc6ddc143e116455c94b25c1004c99e0d0ca12/tests/fuzz/binary/init-corpus/main.go#L51) for instance.

The first makes tendermint builds fail on certain architectures. This PR is a quick-fix for this issue. 
The changes made in this PR were tested (and fuzzed) with a i686 docker image (and locally for 64bit).