### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.15.0 (May 2, 2018)
+
+BREAKING CHANGE:
+ - JSON: Skip null fields on decoding when the `json:"omitempty"` tag is set. 
+ This matches the encoding behaviour ([#261]).  
+ 
+IMPROVEMENTS:
+ - Amino becomes a go-module (requires go 1.11) but keeps dep support for backwards compatibility ([#255]). 
+
+ 
+[#255]: https://github.com/tendermint/go-amino/pull/255 
+[#261]: https://github.com/tendermint/go-amino/issues/261
+ 
 ## 0.14.1 (November 6, 2018)
 
 IMPROVEMENTS:

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,17 @@ gofuzz_binary:
 	rm -rf tests/fuzz/binary/crashers/
 	rm -rf tests/fuzz/binary/suppressions/
 	go run tests/fuzz/binary/init-corpus/main.go --corpus-parent=tests/fuzz/binary
-	go-fuzz-build github.com/tendermint/go-amino/tests/fuzz/binary
-	go-fuzz -bin=./fuzz_binary-fuzz.zip -workdir=tests/fuzz/binary
+	# TODO: update when https://github.com/dvyukov/go-fuzz/issues/195 is resolved
+	GO111MODULE=off go-fuzz-build github.com/tendermint/go-amino/tests/fuzz/binary
+	GO111MODULE=off go-fuzz -bin=./fuzz_binary-fuzz.zip -workdir=tests/fuzz/binary
 
 gofuzz_json:
 	rm -rf tests/fuzz/json/corpus/
 	rm -rf tests/fuzz/json/crashers/
 	rm -rf tests/fuzz/json/suppressions/
-	go-fuzz-build github.com/tendermint/go-amino/tests/fuzz/json
-	go-fuzz -bin=./fuzz_json-fuzz.zip -workdir=tests/fuzz/json
+	# TODO: update when https://github.com/dvyukov/go-fuzz/issues/195 is resolved
+	GO111MODULE=off go-fuzz-build github.com/tendermint/go-amino/tests/fuzz/json
+	GO111MODULE=off go-fuzz -bin=./fuzz_json-fuzz.zip -workdir=tests/fuzz/json
 
 
 ########################################

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package amino
 
 // Version
-const Version = "0.12.0"
+const Version = "0.15.0"


### PR DESCRIPTION
- update changelog
- fix fuzzer via makefile (closes #263)
- bump versions

cc @alexanderbez @fedekunze 
(As a side note: we should probably get rid of the master/develop dichotomy here too).

Ran the JSON fuzzer for over 30 mins. No crashers 🤞 