### PR TITLE
faster VarintSize()

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -42,9 +42,7 @@ func EncodeVarint(w io.Writer, i int64) (err error) {
 }
 
 func VarintSize(i int64) int {
-	var buf [10]byte
-	n := binary.PutVarint(buf[:], i)
-	return n
+	return UvarintSize(uint64((uint64(i) << 1) ^ uint64(i>>63)))
 }
 
 //----------------------------------------


### PR DESCRIPTION
As I tested on my laptop, 

the original one costs:
```
Benchmark_VarintSize-12    	300000000	         6.21 ns/op
```

the optimized one costs:
```
Benchmark_VarintSize2-12    	2000000000	         0.52 ns/op
```