### PR TITLE
disallow multidimensional slices and arrays

### DIFF
--- a/binary-encode.go
+++ b/binary-encode.go
@@ -70,7 +70,18 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 			// for proto3 compatibility, we do not allow multidimensional arrays,
 			// unless the elements involved are bytes (e.g. [][]byte)
 			if info.Type.Elem().Elem().Kind() != reflect.Uint8 { // byte is an alias for uint8
-				err = errors.New("multidimensional arrays not allowed")
+				elem := info.Type.Elem()
+				for {
+					if elem.Kind() == reflect.Slice || elem.Kind() == reflect.Array {
+						elem = elem.Elem()
+						continue
+					}
+					if elem.Kind() == reflect.Uint8 { // byte is an alias for uint8
+						break
+					}
+					err = errors.New("multidimensional arrays not allowed")
+					break
+				}
 			}
 		} else {
 			err = cdc.encodeReflectBinaryList(w, info, rv, fopts, bare)
@@ -82,8 +93,17 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 		} else if info.Type.Elem().Kind() == reflect.Slice || info.Type.Elem().Kind() == reflect.Array {
 			// for proto3 compatibility, we do not allow multidimensional slices,
 			// unless the elements involved are bytes (e.g. [][]byte)
-			if info.Type.Elem().Elem().Kind() != reflect.Uint8 { // byte is an alias for uint8
+			elem := info.Type.Elem()
+			for {
+				if elem.Kind() == reflect.Slice || elem.Kind() == reflect.Array {
+					elem = elem.Elem()
+					continue
+				}
+				if elem.Kind() == reflect.Uint8 { // byte is an alias for uint8
+					break
+				}
 				err = errors.New("multidimensional slices not allowed")
+				break
 			}
 		} else {
 			err = cdc.encodeReflectBinaryList(w, info, rv, fopts, bare)

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -66,6 +66,9 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 	case reflect.Array:
 		if info.Type.Elem().Kind() == reflect.Uint8 {
 			err = cdc.encodeReflectBinaryByteArray(w, info, rv, fopts)
+		} else if info.Type.Elem().Kind() == reflect.Slice || info.Type.Elem().Kind() == reflect.Array {
+			// for proto3 compatibility, we do not allow multidimensional arrays
+			err = errors.New("multidimensional arrays not allowed")
 		} else {
 			err = cdc.encodeReflectBinaryList(w, info, rv, fopts, bare)
 		}
@@ -73,6 +76,9 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 	case reflect.Slice:
 		if info.Type.Elem().Kind() == reflect.Uint8 {
 			err = cdc.encodeReflectBinaryByteSlice(w, info, rv, fopts)
+		} else if info.Type.Elem().Kind() == reflect.Slice || info.Type.Elem().Kind() == reflect.Array {
+			// for proto3 compatibility, we do not allow multidimensional slices
+			err = errors.New("multidimensional slices not allowed")
 		} else {
 			err = cdc.encodeReflectBinaryList(w, info, rv, fopts, bare)
 		}

--- a/tests/common.go
+++ b/tests/common.go
@@ -72,26 +72,6 @@ type SlicesStruct struct {
 	EmptySl   []EmptyStruct
 }
 
-type SliceSlicesStruct struct {
-	Int8SlSl    [][]int8
-	Int16SlSl   [][]int16
-	Int32SlSl   [][]int32
-	Int64SlSl   [][]int64
-	VarintSlSl  [][]int64 `binary:"varint"`
-	IntSlSl     [][]int
-	ByteSlSl    [][]byte
-	Uint8SlSl   [][]uint8
-	Uint16SlSl  [][]uint16
-	Uint32SlSl  [][]uint32
-	Uint64SlSl  [][]uint64
-	UvarintSlSl [][]uint64 `binary:"varint"`
-	UintSlSl    [][]uint
-	StringSlSl  [][]string
-	BytesSlSl   [][][]byte
-	TimeSlSl    [][]time.Time
-	EmptySlSl   [][]EmptyStruct
-}
-
 type PointersStruct struct {
 	Int8Pt    *int8
 	Int16Pt   *int16
@@ -195,7 +175,6 @@ var StructTypes = []interface{}{
 	(*ShortArraysStruct)(nil),
 	(*ArraysStruct)(nil),
 	(*SlicesStruct)(nil),
-	(*SliceSlicesStruct)(nil),
 	(*PointersStruct)(nil),
 	(*PointerSlicesStruct)(nil),
 	(*NestedPointersStruct)(nil),

--- a/tests/proto3/proto3_compat_test.go
+++ b/tests/proto3/proto3_compat_test.go
@@ -108,6 +108,24 @@ func TestFixedU64Roundtrip(t *testing.T) {
 	assert.EqualValues(t, p3ToAm.Int64, amToP3.Int64)
 }
 
+func TestMultidimensionalSlices(t *testing.T) {
+	arr := [][]int8{
+		[]int8{1, 2},
+		[]int8{3, 4}}
+
+	_, err := cdc.MarshalBinaryBare(arr)
+	assert.Error(t, err, "expected error: multidimensional slices are not allowed")
+}
+
+func TestMultidimensionalArrayss(t *testing.T) {
+	arr := [2][2]int8{
+		[2]int8{1, 2},
+		[2]int8{3, 4}}
+
+	_, err := cdc.MarshalBinaryBare(arr)
+	assert.Error(t, err, "expected error: multidimensional arrays are not allowed")
+}
+
 func TestProto3CompatPtrsRoundtrip(t *testing.T) {
 	s := p3.SomeStruct{}
 

--- a/tests/proto3/proto3_compat_test.go
+++ b/tests/proto3/proto3_compat_test.go
@@ -140,6 +140,15 @@ func TestMultidimensionalByteArraysAndSlices(t *testing.T) {
 
 	_, err = cdc.MarshalBinaryBare(s)
 	assert.NoError(t, err, "unexpected error: multidimensional slices are allowed, as long as they are only of bytes")
+
+	s2 := [][][]byte{
+		[][]byte{
+			[]byte{1, 2},
+			[]byte{3, 4, 5}}}
+
+	_, err = cdc.MarshalBinaryBare(s2)
+	assert.NoError(t, err, "unexpected error: multidimensional slices are allowed, as long as they are only of bytes")
+
 }
 
 func TestProto3CompatPtrsRoundtrip(t *testing.T) {

--- a/tests/proto3/proto3_compat_test.go
+++ b/tests/proto3/proto3_compat_test.go
@@ -109,21 +109,37 @@ func TestFixedU64Roundtrip(t *testing.T) {
 }
 
 func TestMultidimensionalSlices(t *testing.T) {
-	arr := [][]int8{
+	s := [][]int8{
 		[]int8{1, 2},
-		[]int8{3, 4}}
+		[]int8{3, 4, 5}}
 
-	_, err := cdc.MarshalBinaryBare(arr)
+	_, err := cdc.MarshalBinaryBare(s)
 	assert.Error(t, err, "expected error: multidimensional slices are not allowed")
 }
 
-func TestMultidimensionalArrayss(t *testing.T) {
+func TestMultidimensionalArrays(t *testing.T) {
 	arr := [2][2]int8{
 		[2]int8{1, 2},
 		[2]int8{3, 4}}
 
 	_, err := cdc.MarshalBinaryBare(arr)
 	assert.Error(t, err, "expected error: multidimensional arrays are not allowed")
+}
+
+func TestMultidimensionalByteArraysAndSlices(t *testing.T) {
+	arr := [2][2]byte{
+		[2]byte{1, 2},
+		[2]byte{3, 4}}
+
+	_, err := cdc.MarshalBinaryBare(arr)
+	assert.NoError(t, err, "unexpected error: multidimensional arrays are allowed, as long as they are only of bytes")
+
+	s := [][]byte{
+		[]byte{1, 2},
+		[]byte{3, 4, 5}}
+
+	_, err = cdc.MarshalBinaryBare(s)
+	assert.NoError(t, err, "unexpected error: multidimensional slices are allowed, as long as they are only of bytes")
 }
 
 func TestProto3CompatPtrsRoundtrip(t *testing.T) {


### PR DESCRIPTION
Stop allowing multidimensional slices and arrays, in order to increase proto3 compatibility. Addresses #272.

This is my first PR, and a little bit of a shot in the dark, so please let me know if I need to restructure anything! 