### PR TITLE
bugfix: fields with tag "write_empty" are not marshaled correctly

### DIFF
--- a/binary-encode.go
+++ b/binary-encode.go
@@ -439,7 +439,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 			var frv = rv.Field(field.Index)
 			var frvIsPtr = frv.Kind() == reflect.Ptr
 			var dfrv, isDefault = isDefaultValue(frv)
-			if isDefault && !fopts.WriteEmpty {
+			if isDefault && !field.WriteEmpty {
 				// Do not encode default value fields
 				// (except when `amino:"write_empty"` is set).
 				continue
@@ -452,7 +452,7 @@ func (cdc *Codec) encodeReflectBinaryStruct(w io.Writer, info *TypeInfo, rv refl
 				}
 			} else {
 				// write empty if explicitly set or if this is a pointer:
-				writeEmpty := fopts.WriteEmpty || frvIsPtr
+				writeEmpty := field.WriteEmpty || frvIsPtr
 				err = cdc.writeFieldIfNotEmpty(buf, field.BinFieldNum, finfo, fopts, field.FieldOptions, dfrv, writeEmpty, false)
 				if err != nil {
 					return

--- a/binary_test.go
+++ b/binary_test.go
@@ -149,13 +149,11 @@ func TestForceWriteEmpty(t *testing.T) {
 
 	b, err := cdc.MarshalBinaryBare(OuterWriteEmpty{})
 	assert.NoError(t, err)
-	assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
+	assert.Equal(t, []byte{10, 5, 13, 0, 0, 0, 0, 16, 0}, b)
 
 	b, err = cdc.MarshalBinaryBare(InnerWriteEmpty{})
 	assert.NoError(t, err)
-	t.Log(b)
-	// TODO(ismail): this alone won't be encoded:
-	//assert.NotZero(t, len(b), "amino:\"write_empty\" did not work")
+	assert.Equal(t, []byte{13, 0, 0, 0, 0}, b)
 }
 
 func TestStructSlice(t *testing.T) {


### PR DESCRIPTION
as the titled described, the implementation of write_empty is not correct, fields with write_empty tag may still be marshaled to empty bytes.

```go
func TestForceWriteEmpty(t *testing.T) {
type InnerWriteEmpty struct {
    // sth. that isn't zero-len if default, e.g. fixed32:
    ValIn int32 `amino:"write_empty" binary:"fixed32"`
}

type OuterWriteEmpty struct {
    In  InnerWriteEmpty `amino:"write_empty"`
    Val int             `amino:"write_empty" binary:"fixed32"`
}

cdc := amino.NewCodec()

b, err := cdc.MarshalBinaryBare(OuterWriteEmpty{})
assert.NoError(t, err)
assert.Equal(t, []byte{10, 5, 13, 0, 0, 0, 0, 16, 0}, b)

b, err = cdc.MarshalBinaryBare(InnerWriteEmpty{})
assert.NoError(t, err)
assert.Equal(t, []byte{13, 0, 0, 0, 0,}, b)
}
```
the result is 
```
Error:          Not equal: 
                        expected: []byte{0xa, 0x5, 0xd, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0}
                        actual  : []byte{0xa, 0x5, 0xd, 0x0, 0x0, 0x0, 0x0}

Error:          Not equal: 
                        expected: []byte{0xd, 0x0, 0x0, 0x0, 0x0}
                        actual  : []byte(nil)
```
