### PR TITLE
Getters for data on Codec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -147,6 +147,18 @@ func NewCodec() *Codec {
 	return cdc
 }
 
+func (cdc *Codec) TypeInfos() map[reflect.Type]*TypeInfo {
+	return cdc.typeInfos
+}
+
+func (cdc *Codec) TypeInfosByName() map[string]*TypeInfo {
+	return cdc.nameToTypeInfo
+}
+
+func (cdc *Codec) DisFixToTypeInfo() map[DisfixBytes]*TypeInfo {
+	return cdc.disfixToTypeInfo
+}
+
 // This function should be used to register all interfaces that will be
 // encoded/decoded by go-amino.
 // Usage:


### PR DESCRIPTION
Expose read on typeInfos data to allow for client side code generation. Allowing users read access to these types would allow for generation of (for example) typescript definitions.