### PR TITLE
Fix bug in function decodeReflectJSONStruct

### DIFF
--- a/json-decode.go
+++ b/json-decode.go
@@ -362,7 +362,7 @@ func (cdc *Codec) decodeReflectJSONSlice(bz []byte, info *TypeInfo, rv reflect.V
 }
 
 // CONTRACT: rv.CanAddr() is true.
-func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.Value, fopts FieldOptions) (err error) {
+func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.Value, _ FieldOptions) (err error) {
 	if !rv.CanAddr() {
 		panic("rv not addressable")
 	}
@@ -413,7 +413,7 @@ func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.
 		}
 
 		// Decode into field rv.
-		err = cdc.decodeReflectJSON(valueBytes, finfo, frv, fopts)
+		err = cdc.decodeReflectJSON(valueBytes, finfo, frv, field.FieldOptions)
 		if err != nil {
 			return
 		}

--- a/json-decode.go
+++ b/json-decode.go
@@ -105,7 +105,7 @@ func (cdc *Codec) decodeReflectJSON(bz []byte, info *TypeInfo, rv reflect.Value,
 		err = cdc.decodeReflectJSONSlice(bz, info, rv, fopts)
 
 	case reflect.Struct:
-		err = cdc.decodeReflectJSONStruct(bz, info, rv, fopts)
+		err = cdc.decodeReflectJSONStruct(bz, info, rv)
 
 	case reflect.Map:
 		err = cdc.decodeReflectJSONMap(bz, info, rv, fopts)
@@ -362,7 +362,7 @@ func (cdc *Codec) decodeReflectJSONSlice(bz []byte, info *TypeInfo, rv reflect.V
 }
 
 // CONTRACT: rv.CanAddr() is true.
-func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.Value, _ FieldOptions) (err error) {
+func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.Value) (err error) {
 	if !rv.CanAddr() {
 		panic("rv not addressable")
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -23,6 +23,7 @@ func registerTransports(cdc *amino.Codec) {
 	cdc.RegisterConcrete(insurancePlan(0), "insuranceplan", nil)
 	cdc.RegisterConcrete(Boat(""), "boat", nil)
 	cdc.RegisterConcrete(Plane{}, "plane", nil)
+	cdc.RegisterConcrete(Unsafe{}, "unsafe", nil)
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -101,6 +102,7 @@ func TestMarshalJSON(t *testing.T) {
 		}{FP: &fp{"Foo", 10}, Package: "bytes"},
 			`{"FP":<FP-MARSHALJSON>,"Package":"bytes"}`, "",
 		}, // #23,
+		{Unsafe{Number: 3.14}, `{"type":"unsafe","value":{"Number":3.14}}`, ""}, // #24
 	}
 
 	for i, tt := range cases {
@@ -276,6 +278,13 @@ func TestUnmarshalJSON(t *testing.T) {
 		},
 		{ // #14
 			`{"PC":"125","FP":"<FP-FOO>"}`, new(innerFP), &innerFP{PC: 125, FP: &fp{Name: `"<FP-FOO>"`}}, "",
+		},
+		{ // #15
+			`{"type":"unsafe","value":{"Number":3.14}}`,
+			new(Unsafe),
+			&Unsafe{
+				Number: 3.14,
+			}, "",
 		},
 	}
 
@@ -465,6 +474,10 @@ func (p Plane) Move() error { return nil }
 
 func interfacePtr(v interface{}) *interface{} {
 	return &v
+}
+
+type Unsafe struct {
+	Number float64 `amino:"unsafe"`
 }
 
 // Test to ensure that Amino codec's time encoding/decoding roundtrip


### PR DESCRIPTION
This PR fixes a bug in the function `decodeReflectJSONStruct`.

To decode each field of the struct, this function is calling `decodeReflectJSON`. The issue was instead of using each `field.FieldOptions`, it was passing its parameter `fopts FieldOptions`:
https://github.com/tendermint/go-amino/blob/59d50ef176f686dc2c0c150e85a9381a78b9978a/json-decode.go#L416

The binary version `decodeReflectBinaryStruct` is already using each `field.FieldOptions`, so I just apply the same logic to the json version.
https://github.com/tendermint/go-amino/blob/59d50ef176f686dc2c0c150e85a9381a78b9978a/binary-decode.go#L867

I also add a new `Unsafe` struct to `json_test.go` to unit test the issue. Without the fix, the tests are failing.

---

Here is the link to the failed CI test before the fix: https://app.circleci.com/jobs/github/tendermint/go-amino/670