### PR TITLE
Add codec method to retrieve a Go type registered name

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -308,6 +308,30 @@ func (cdc *Codec) PrintTypes(out io.Writer) error {
 	return nil
 }
 
+// ConcreteRegisteredName returns the name under which i has been registered.
+func (cdc *Codec) ConcreteRegisteredName(i interface{}) (string, error) {
+	cdc.mtx.RLock()
+	defer cdc.mtx.RUnlock()
+
+	if i == nil {
+		return "", errors.New("argument must not be nil")
+	}
+
+	gt := reflect.TypeOf(i)
+
+	// if i is a non-nil pointer, dereference it and grab its inner Elem
+	if gt.Kind() == reflect.Ptr {
+		gt = gt.Elem()
+	}
+
+	ct, ok := cdc.typeInfos[gt]
+	if !ok {
+		return "", fmt.Errorf("no type registered for %s", gt.String())
+	}
+
+	return ct.Name, nil
+}
+
 // A heuristic to guess the size of a registered type and return it as a string.
 // If the size is not fixed it returns "variable".
 func getLengthStr(info *TypeInfo) string {

--- a/codec_test.go
+++ b/codec_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/go-amino"
 )
 
 type SimpleStruct struct {
@@ -249,4 +249,34 @@ func TestCodecSeal(t *testing.T) {
 
 	assert.Panics(t, func() { cdc.RegisterInterface((*Bar)(nil), nil) })
 	assert.Panics(t, func() { cdc.RegisterConcrete(int(0), "int", nil) })
+}
+
+func TestCodec_RegisteredName(t *testing.T) {
+	aminoStructType := "tendermint/SimpleStruct"
+
+	// Struct is registered
+	cdc := amino.NewCodec()
+	cdc.RegisterConcrete(SimpleStruct{}, aminoStructType, nil)
+	rn, err := cdc.ConcreteRegisteredName(SimpleStruct{})
+	require.NoError(t, err)
+	require.Equal(t, aminoStructType, rn)
+
+	// Struct is not registered
+	cdc = amino.NewCodec()
+	rn, err = cdc.ConcreteRegisteredName(SimpleStruct{})
+	require.Error(t, err)
+	require.Empty(t, rn)
+
+	// Struct is pointer
+	cdc = amino.NewCodec()
+	cdc.RegisterConcrete(SimpleStruct{}, aminoStructType, nil)
+	rn, err = cdc.ConcreteRegisteredName(&SimpleStruct{})
+	require.NoError(t, err)
+	require.Equal(t, aminoStructType, rn)
+
+	// Struct is nil pointer
+	cdc = amino.NewCodec()
+	rn, err = cdc.ConcreteRegisteredName(nil)
+	require.Error(t, err)
+	require.Empty(t, rn)
 }


### PR DESCRIPTION
Given a codec, users might want to know what's the Amino type associated
with a given struct instance.

This commit adds the functionality needed to do that, for both instance and pointer-to-instance
types.

Nil interfaces are rejected by default.

Method completed with tests.

---

We are in the process of writing various SDKs for our project ([commercionetwork](http://github.com/commercionetwork/commercionetwork)), and for the Go one we thought it might be a great idea to simply reuse all the types implemented in our modules.

We need to know at runtime Amino message types for every possible type in order to construct a well-defined Cosmos REST transaction message.

Right now, we manually parse `codec.PrintTypes()` output and build a map which associates Go type to its Amino name.

This patch integrates basically the same idea, by leveraging the codec's integrated type map.