### PR TITLE
Add support for (Un)MarshalAminoJSON override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## 0.16.0 (September 11, 2020)
+
+IMPROVEMENTS:
+ - Add support for `Un/MarshalAminoJSON` override: if a type implements
+ `Un/MarshalAminoJSON`, then amino will use these methods for JSON un/marshalling
+ ([#323]).
+
+[#323]: https://github.com/tendermint/go-amino/pull/323
+
 ## 0.15.1 (October 10, 2019)
 
 ### IMPROVEMENTS:

--- a/binary-encode.go
+++ b/binary-encode.go
@@ -37,7 +37,7 @@ func (cdc *Codec) encodeReflectBinary(w io.Writer, info *TypeInfo, rv reflect.Va
 		}()
 	}
 
-	// Handle override if rv implements json.Marshaler.
+	// Handle override if rv implements MarshalAmino.
 	if info.IsAminoMarshaler {
 		// First, encode rv into repr instance.
 		var rrv, rinfo = reflect.Value{}, (*TypeInfo)(nil)

--- a/codec.go
+++ b/codec.go
@@ -88,10 +88,10 @@ type ConcreteInfo struct {
 	AminoMarshalReprType       reflect.Type // <ReprType>
 	IsAminoUnmarshaler         bool         // Implements UnmarshalAmino(<ReprObject>) (error).
 	AminoUnmarshalReprType     reflect.Type // <ReprType>
-	IsAminoMarshalerJSON       bool         // Implements MarshalAminoJSON() (<ReprObject>, error).
-	AminoMarshalJSONReprType   reflect.Type // <ReprType>
-	IsAminoUnmarshalerJSON     bool         // Implements UnmarshalAminoJSON(<ReprObject>) (error).
-	AminoUnmarshalJSONReprType reflect.Type // <ReprType>
+	IsAminoJSONMarshaler       bool         // Implements MarshalAminoJSON() (<ReprObject>, error).
+	AminoJSONMarshalReprType   reflect.Type // <ReprType>
+	IsAminoJSONUnmarshaler     bool         // Implements UnmarshalAminoJSON(<ReprObject>) (error).
+	AminoJSONUnmarshalReprType reflect.Type // <ReprType>
 }
 
 type StructInfo struct {

--- a/codec.go
+++ b/codec.go
@@ -84,10 +84,14 @@ type ConcreteInfo struct {
 
 	// These fields get set for all concrete types,
 	// even those not manually registered (e.g. are never interface values).
-	IsAminoMarshaler       bool         // Implements MarshalAmino() (<ReprObject>, error).
-	AminoMarshalReprType   reflect.Type // <ReprType>
-	IsAminoUnmarshaler     bool         // Implements UnmarshalAmino(<ReprObject>) (error).
-	AminoUnmarshalReprType reflect.Type // <ReprType>
+	IsAminoMarshaler           bool         // Implements MarshalAmino() (<ReprObject>, error).
+	AminoMarshalReprType       reflect.Type // <ReprType>
+	IsAminoUnmarshaler         bool         // Implements UnmarshalAmino(<ReprObject>) (error).
+	AminoUnmarshalReprType     reflect.Type // <ReprType>
+	IsAminoMarshalerJSON       bool         // Implements MarshalAminoJSON() (<ReprObject>, error).
+	AminoMarshalJSONReprType   reflect.Type // <ReprType>
+	IsAminoUnmarshalerJSON     bool         // Implements UnmarshalAminoJSON(<ReprObject>) (error).
+	AminoUnmarshalJSONReprType reflect.Type // <ReprType>
 }
 
 type StructInfo struct {
@@ -566,6 +570,14 @@ func (cdc *Codec) newTypeInfoUnregistered(rt reflect.Type) *TypeInfo {
 		info.ConcreteInfo.IsAminoUnmarshaler = true
 		info.ConcreteInfo.AminoUnmarshalReprType = unmarshalAminoReprType(rm)
 	}
+	if rm, ok := rt.MethodByName("MarshalAminoJSON"); ok {
+		info.ConcreteInfo.IsAminoMarshalerJSON = true
+		info.ConcreteInfo.AminoMarshalJSONReprType = marshalAminoJSONReprType(rm)
+	}
+	if rm, ok := reflect.PtrTo(rt).MethodByName("UnmarshalAminoJSON"); ok {
+		info.ConcreteInfo.IsAminoUnmarshalerJSON = true
+		info.ConcreteInfo.AminoUnmarshalJSONReprType = unmarshalAminoJSONReprType(rm)
+	}
 	return info
 }
 
@@ -797,6 +809,45 @@ func unmarshalAminoReprType(rm reflect.Method) (rrt reflect.Type) {
 	}
 	if out := rm.Type.Out(0); out != errorType {
 		panic(fmt.Sprintf("UnmarshalAmino should have first output parameter of error type, got %v", out))
+	}
+	rrt = rm.Type.In(1)
+	if rrt.Kind() == reflect.Ptr {
+		panic(fmt.Sprintf("Representative objects cannot be pointers; got %v", rrt))
+	}
+	return
+}
+
+func marshalAminoJSONReprType(rm reflect.Method) (rrt reflect.Type) {
+	// Verify form of this method.
+	if rm.Type.NumIn() != 1 {
+		panic(fmt.Sprintf("MarshalAminoJSON should have 1 input parameters (including receiver); got %v", rm.Type))
+	}
+	if rm.Type.NumOut() != 2 {
+		panic(fmt.Sprintf("MarshalAminoJSON should have 2 output parameters; got %v", rm.Type))
+	}
+	if out := rm.Type.Out(1); out != errorType {
+		panic(fmt.Sprintf("MarshalAminoJSON should have second output parameter of error type, got %v", out))
+	}
+	rrt = rm.Type.Out(0)
+	if rrt.Kind() == reflect.Ptr {
+		panic(fmt.Sprintf("Representative objects cannot be pointers; got %v", rrt))
+	}
+	return
+}
+
+func unmarshalAminoJSONReprType(rm reflect.Method) (rrt reflect.Type) {
+	// Verify form of this method.
+	if rm.Type.NumIn() != 2 {
+		panic(fmt.Sprintf("UnmarshalAminoJSON should have 2 input parameters (including receiver); got %v", rm.Type))
+	}
+	if in1 := rm.Type.In(0); in1.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("UnmarshalAminoJSON first input parameter should be pointer type but got %v", in1))
+	}
+	if rm.Type.NumOut() != 1 {
+		panic(fmt.Sprintf("UnmarshalAminoJSON should have 1 output parameters; got %v", rm.Type))
+	}
+	if out := rm.Type.Out(0); out != errorType {
+		panic(fmt.Sprintf("UnmarshalAminoJSON should have first output parameter of error type, got %v", out))
 	}
 	rrt = rm.Type.In(1)
 	if rrt.Kind() == reflect.Ptr {

--- a/codec.go
+++ b/codec.go
@@ -571,12 +571,12 @@ func (cdc *Codec) newTypeInfoUnregistered(rt reflect.Type) *TypeInfo {
 		info.ConcreteInfo.AminoUnmarshalReprType = unmarshalAminoReprType(rm)
 	}
 	if rm, ok := rt.MethodByName("MarshalAminoJSON"); ok {
-		info.ConcreteInfo.IsAminoMarshalerJSON = true
-		info.ConcreteInfo.AminoMarshalJSONReprType = marshalAminoJSONReprType(rm)
+		info.ConcreteInfo.IsAminoJSONMarshaler = true
+		info.ConcreteInfo.AminoJSONMarshalReprType = marshalAminoJSONReprType(rm)
 	}
 	if rm, ok := reflect.PtrTo(rt).MethodByName("UnmarshalAminoJSON"); ok {
-		info.ConcreteInfo.IsAminoUnmarshalerJSON = true
-		info.ConcreteInfo.AminoUnmarshalJSONReprType = unmarshalAminoJSONReprType(rm)
+		info.ConcreteInfo.IsAminoJSONUnmarshaler = true
+		info.ConcreteInfo.AminoJSONUnmarshalReprType = unmarshalAminoJSONReprType(rm)
 	}
 	return info
 }

--- a/json-decode.go
+++ b/json-decode.go
@@ -61,11 +61,11 @@ func (cdc *Codec) decodeReflectJSON(bz []byte, info *TypeInfo, rv reflect.Value,
 	}
 
 	// Handle override if a pointer to rv implements UnmarshalAminoJSON.
-	if info.IsAminoUnmarshalerJSON {
+	if info.IsAminoJSONUnmarshaler {
 		// First, decode repr instance from JSON.
-		rrv := reflect.New(info.AminoUnmarshalJSONReprType).Elem()
+		rrv := reflect.New(info.AminoJSONUnmarshalReprType).Elem()
 		var rinfo *TypeInfo
-		rinfo, err = cdc.getTypeInfoWlock(info.AminoUnmarshalJSONReprType)
+		rinfo, err = cdc.getTypeInfoWlock(info.AminoJSONUnmarshalReprType)
 		if err != nil {
 			return
 		}

--- a/json-decode.go
+++ b/json-decode.go
@@ -65,7 +65,7 @@ func (cdc *Codec) decodeReflectJSON(bz []byte, info *TypeInfo, rv reflect.Value,
 		// First, decode repr instance from JSON.
 		rrv := reflect.New(info.AminoJSONUnmarshalReprType).Elem()
 		var rinfo *TypeInfo
-		rinfo, err = cdc.getTypeInfoWlock(info.AminoJSONUnmarshalReprType)
+		rinfo, err = cdc.getTypeInfo_wlock(info.AminoJSONUnmarshalReprType)
 		if err != nil {
 			return
 		}
@@ -424,7 +424,7 @@ func (cdc *Codec) decodeReflectJSONStruct(bz []byte, info *TypeInfo, rv reflect.
 				// Set nil/zero on frv.
 				frv.Set(reflect.Zero(frv.Type()))
 			}
-			
+
 			continue
 		}
 

--- a/json-encode.go
+++ b/json-encode.go
@@ -48,16 +48,6 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		ct := rv.Interface().(time.Time).Round(0).UTC()
 		rv = reflect.ValueOf(ct)
 	}
-	// Handle override if rv implements json.Marshaler.
-	if rv.CanAddr() { // Try pointer first.
-		if rv.Addr().Type().Implements(jsonMarshalerType) {
-			err = invokeMarshalJSON(w, rv.Addr())
-			return
-		}
-	} else if rv.Type().Implements(jsonMarshalerType) {
-		err = invokeMarshalJSON(w, rv)
-		return
-	}
 
 	// Handle override if rv implements MarshalAminoJSON.
 	if info.IsAminoMarshalerJSON {
@@ -76,6 +66,17 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		}
 		// Then, encode the repr instance.
 		err = cdc.encodeReflectJSON(w, rinfo, rrv, fopts)
+		return
+	}
+
+	// Handle override if rv implements json.Marshaler.
+	if rv.CanAddr() { // Try pointer first.
+		if rv.Addr().Type().Implements(jsonMarshalerType) {
+			err = invokeMarshalJSON(w, rv.Addr())
+			return
+		}
+	} else if rv.Type().Implements(jsonMarshalerType) {
+		err = invokeMarshalJSON(w, rv)
 		return
 	}
 

--- a/json-encode.go
+++ b/json-encode.go
@@ -50,7 +50,7 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 	}
 
 	// Handle override if rv implements MarshalAminoJSON.
-	if info.IsAminoMarshalerJSON {
+	if info.IsAminoJSONMarshaler {
 		// First, encode rv into repr instance.
 		var (
 			rrv   reflect.Value
@@ -60,7 +60,7 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		if err != nil {
 			return
 		}
-		rinfo, err = cdc.getTypeInfoWlock(info.AminoMarshalJSONReprType)
+		rinfo, err = cdc.getTypeInfoWlock(info.AminoJSONMarshalReprType)
 		if err != nil {
 			return
 		}

--- a/json-encode.go
+++ b/json-encode.go
@@ -59,7 +59,38 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		return
 	}
 
+	// Handle override if rv implements MarshalAminoJSON.
+	if info.IsAminoMarshalerJSON {
+		// First, encode rv into repr instance.
+		var (
+			rrv   reflect.Value
+			rinfo *TypeInfo
+		)
+		rrv, err = toReprJSONObject(rv)
+		if err != nil {
+			return
+		}
+		rinfo, err = cdc.getTypeInfoWlock(info.AminoMarshalJSONReprType)
+		if err != nil {
+			return
+		}
+		// Then, encode the repr instance.
+		err = cdc.encodeReflectJSON(w, rinfo, rrv, fopts)
+		return
+	}
+
 	// Handle override if rv implements json.Marshaler.
+	if rv.CanAddr() { // Try pointer first.
+		if rv.Addr().Type().Implements(jsonMarshalerType) {
+			err = invokeMarshalJSON(w, rv.Addr())
+			return
+		}
+	} else if rv.Type().Implements(jsonMarshalerType) {
+		err = invokeMarshalJSON(w, rv)
+		return
+	}
+
+	// Handle override if rv implements MarshalAmino.
 	if info.IsAminoMarshaler {
 		// First, encode rv into repr instance.
 		var rrv, rinfo = reflect.Value{}, (*TypeInfo)(nil)

--- a/json-encode.go
+++ b/json-encode.go
@@ -80,17 +80,6 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		return
 	}
 
-	// Handle override if rv implements json.Marshaler.
-	if rv.CanAddr() { // Try pointer first.
-		if rv.Addr().Type().Implements(jsonMarshalerType) {
-			err = invokeMarshalJSON(w, rv.Addr())
-			return
-		}
-	} else if rv.Type().Implements(jsonMarshalerType) {
-		err = invokeMarshalJSON(w, rv)
-		return
-	}
-
 	// Handle override if rv implements MarshalAmino.
 	if info.IsAminoMarshaler {
 		// First, encode rv into repr instance.

--- a/json-encode.go
+++ b/json-encode.go
@@ -60,7 +60,7 @@ func (cdc *Codec) encodeReflectJSON(w io.Writer, info *TypeInfo, rv reflect.Valu
 		if err != nil {
 			return
 		}
-		rinfo, err = cdc.getTypeInfoWlock(info.AminoJSONMarshalReprType)
+		rinfo, err = cdc.getTypeInfo_wlock(info.AminoJSONMarshalReprType)
 		if err != nil {
 			return
 		}

--- a/reflect.go
+++ b/reflect.go
@@ -243,3 +243,22 @@ func toReprObject(rv reflect.Value) (rrv reflect.Value, err error) {
 	rrv = mwouts[0]
 	return
 }
+
+func toReprJSONObject(rv reflect.Value) (rrv reflect.Value, err error) {
+	var mwrm reflect.Value
+	if rv.CanAddr() {
+		mwrm = rv.Addr().MethodByName("MarshalAminoJSON")
+	} else {
+		mwrm = rv.MethodByName("MarshalAminoJSON")
+	}
+	mwouts := mwrm.Call(nil)
+	if !mwouts[1].IsNil() {
+		erri := mwouts[1].Interface()
+		if erri != nil {
+			err = erri.(error)
+			return rrv, err
+		}
+	}
+	rrv = mwouts[0]
+	return
+}


### PR DESCRIPTION
ref: https://github.com/cosmos/cosmos-sdk/issues/7109#issuecomment-689709943

If a type implements `MarshalAminoJSON` and `UnmarshalAminoJSON`, then amino will use these methods for JSON marshaling.

This is the json-equivalent for methods `MarshalAmino` and `UnmarshalAmino`

also cc @alexanderbez, since I can't add you as a reviewer